### PR TITLE
Find and copy libstdc++-6.dll from building system

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ td-agent-builder is a new build system for [td-agent](http://docs.treasuredata.c
   * Any host OS that is supported by Docker
     * Debian buster or Ubuntu 18.04 are recommended
   * [Docker](https://docs.docker.com/install/)
-  * Ruby 2.2 or later
+  * Ruby 2.4 or later
   * Git
 
 ### For building Windows package (.msi)
@@ -19,7 +19,7 @@ td-agent-builder is a new build system for [td-agent](http://docs.treasuredata.c
   * Windows OS (10 or 2019 are verified)
   * [Docker Desktop for Windows](https://hub.docker.com/editions/community/docker-ce-desktop-windows)
     * You need to switch to "Windows containers" before using it.
-  * [RubyInstaller](https://rubyinstaller.org/) 2.2 or later.
+  * [RubyInstaller](https://rubyinstaller.org/) 2.4 or later.
   * [Git for Windows](https://gitforwindows.org/)
 
 ## How to build .rpm package

--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -256,6 +256,7 @@ class BuildTask
         if windows?
           extract_ruby_installer
           setup_windows_build_env
+          find_and_put_dynamiclibs
         else
           build_ruby_from_source
         end
@@ -528,6 +529,27 @@ class BuildTask
          path)
       cp_r(Dir.glob(File.join(src_dir, "*")), ".")
       rm_rf(src_dir)
+    end
+  end
+
+  def find_and_put_dynamiclibs
+    begin
+      require 'ruby_installer/runtime'
+
+      dlls = [
+        "libstdc++-6",
+      ]
+      dlls.each do |dll|
+        mingw_bin_path = RubyInstaller::Runtime.msys2_installation.mingw_bin_path
+        windows_path = "#{mingw_bin_path}/#{dll}.dll"
+        if File.exist?(windows_path)
+          copy windows_path, staging_bindir
+        else
+          raise "Cannot find required DLL needed for dynamic linking: #{windows_path}"
+        end
+      end
+    rescue LoadError
+      raise "Cannot load RubyInstaller::Runtime class"
     end
   end
 

--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -536,6 +536,8 @@ class BuildTask
     begin
       require 'ruby_installer/runtime'
 
+      # These dlls are required to put in staging_bindir to run C++ based extension
+      # included gem such as winevt_c. We didn't find how to link them statically yet.
       dlls = [
         "libstdc++-6",
       ]


### PR DESCRIPTION
This will be fixing #98.

And this patch is inspired by https://github.com/treasure-data/omnibus-td-agent/blob/05a1f1a43732383828f4cbec47e393773c14acea/config/software/ruby.rb#L296-L323.