### PR TITLE
rpm: fix W: only-non-binary-in-usr-lib on CentOS 7

### DIFF
--- a/td-agent/yum/rpmlint.config
+++ b/td-agent/yum/rpmlint.config
@@ -37,3 +37,5 @@ addFilter("W: dangerous-command-in-%post cp")
 # It is intended to ignore under /opt/td-agent for ld.so.cache
 addFilter("E: postin-without-ldconfig")
 addFilter("E: library-without-ldconfig-postun")
+# It is intended to ignore non-binary under /usr/lib (systemd,tempfiles.d) on CentOS 7
+addFilter("W: only-non-binary-in-usr-lib")


### PR DESCRIPTION
Under /usr/lib/*, systemd or tmpfiles.d configuration
files are put.

