### PR TITLE
rpm: fix W: incoherent-subsys

### DIFF
--- a/td-agent/yum/rpmlint.config
+++ b/td-agent/yum/rpmlint.config
@@ -41,3 +41,5 @@ addFilter("E: library-without-ldconfig-postun")
 addFilter("W: only-non-binary-in-usr-lib")
 # It is intended to use Default-Start:
 addFilter("W: service-default-enabled")
+# It is intended to ignore false positive line in /etc/init.d/td-agent (/var/lock/subsys/${prog})
+addFilter("W: incoherent-subsys")


### PR DESCRIPTION
In /etc/init.d/td-agent, rpmlint reports /var/lock/subsys is
incoherent.

It seems that TD_AGENT_LOCK_FILE="/var/lock/subsys/${prog}" in
/etc/init.d/td-agent is regarded as incoherent because
it is not /var/lock/subsys/td-agent. Thus it is false positive.