### PR TITLE
Use latest fluent-plugin-windows-eventlog

### DIFF
--- a/td-agent/plugin_gems.rb
+++ b/td-agent/plugin_gems.rb
@@ -47,6 +47,6 @@ end
 
 if windows?
   download 'win32-eventlog', '0.6.7'
-  download 'winevt_c', '0.7.4'
-  download 'fluent-plugin-windows-eventlog', '0.5.4'
+  download 'winevt_c', '0.8.1'
+  download 'fluent-plugin-windows-eventlog', '0.7.1.rc1'
 end


### PR DESCRIPTION
It fixes the issue that rc version of nokogiri (1.11 rc2) which supports ruby 2.7.1
is not installed

ref. https://github.com/sparklemotion/nokogiri/issues/2029