### PR TITLE
Use WiX makable release candidate version

### DIFF
--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -244,6 +244,15 @@ class BuildTask
     @download_task = download_task
   end
 
+  def make_wix_version_numer(version)
+    if version.split("~")[1]
+      version_base = version.split("~")[0].chars.delete_if{|e| e == "."}.join("").to_i.pred.to_s.chars.join(".")
+      version_base + "." + Time.now.strftime("%m%d")
+    else
+      version
+    end
+  end
+
   def define
     namespace :build do
       desc "Install jemalloc"
@@ -396,7 +405,8 @@ class BuildTask
       task :wix_config do
         src  = File.join('msi', 'parameters.wxi.erb')
         dest = File.join('msi', 'parameters.wxi')
-        render_template(dest, src, template_params)
+        params = {wix_package_version: make_wix_version_numer(PACKAGE_VERSION)}
+        render_template(dest, src, template_params(params))
       end
 
       desc "Create configuration files for Red Hat like systems with systemd"

--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -244,13 +244,12 @@ class BuildTask
     @download_task = download_task
   end
 
-  def make_wix_version_numer(version)
-    if version.split("~")[1]
-      version_base = version.split("~")[0].chars.delete_if{|e| e == "."}.join("").to_i.pred.to_s.chars.join(".")
-      version_base + "." + Time.now.strftime("%m%d")
-    else
-      version
-    end
+  def make_wix_version_number(version)
+    return version unless version.include?("~")
+    "%s.%s" % [
+      version.split("~", 2)[0].delete(".").to_i.pred.to_s.chars.join("."),
+      Time.now.strftime("%m%d")
+    ]
   end
 
   def define
@@ -405,7 +404,7 @@ class BuildTask
       task :wix_config do
         src  = File.join('msi', 'parameters.wxi.erb')
         dest = File.join('msi', 'parameters.wxi')
-        params = {wix_package_version: make_wix_version_numer(PACKAGE_VERSION)}
+        params = {wix_package_version: make_wix_version_number(PACKAGE_VERSION)}
         render_template(dest, src, template_params(params))
       end
 

--- a/td-agent/msi/parameters.wxi.erb
+++ b/td-agent/msi/parameters.wxi.erb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Include>
-  <?define VersionNumber="<%= version %>" ?>
-  <?define DisplayVersionNumber="<%= version %>" ?>
+  <?define VersionNumber="<%= wix_package_version %>" ?>
+  <?define DisplayVersionNumber="<%= wix_package_version %>" ?>
   <?define UpgradeCode="76dcb0b2-81ad-4a07-bf3b-1db567594171" ?>
 </Include>

--- a/td-agent/msi/parameters.wxi.erb
+++ b/td-agent/msi/parameters.wxi.erb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Include>
   <?define VersionNumber="<%= wix_package_version %>" ?>
-  <?define DisplayVersionNumber="<%= wix_package_version %>" ?>
+  <?define DisplayVersionNumber="<%= version %>" ?>
   <?define UpgradeCode="76dcb0b2-81ad-4a07-bf3b-1db567594171" ?>
 </Include>


### PR DESCRIPTION
Wix using package version should be modified into buildable version number.
This is one of the possible prerelease version implementation.

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>