### PR TITLE
Support ~alphaN, ~betaN, and ~rcN version

### DIFF
--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -246,9 +246,20 @@ class BuildTask
 
   def make_wix_version_number(version)
     return version unless version.include?("~")
+    revision = ""
+    case version
+    when /~rc(\d+)/
+      revision = $1.to_i * 10000 + Time.now.hour
+    when /~beta(\d+)/
+      revision = $1.to_i * 1000 + Time.now.hour
+    when /~alpha(\d+)/
+      revision = $1.to_i * 100 + Time.now.hour
+    else
+      fail "Failed to download #{gem}!" unless $?.success?
+    end
     "%s.%s" % [
       version.split("~", 2)[0].delete(".").to_i.pred.to_s.chars.join("."),
-      Time.now.strftime("%m%d")
+      revision
     ]
   end
 

--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -257,6 +257,9 @@ class BuildTask
     else
       fail "Failed to download #{gem}!" unless $?.success?
     end
+    if revision > 65534
+      fail "revision must be an integer, from 0 to 65534: <#{revision}>"
+    end
     "%s.%s" % [
       version.split("~", 2)[0].delete(".").to_i.pred.to_s.chars.join("."),
       revision


### PR DESCRIPTION
Additionally, build time (hour) is also considered
for CI.

   ~rc1: x.x.x.10009 if ~rc1 is built at 9am
 ~beta1: x.x.x.1009  if ~beta1 is built at 9am
~alpha1: x.x.x.109   if ~alpha1 is built at 9am