### PR TITLE
Bundle fluent-plugin-parser-winevt_xml plugin

### DIFF
--- a/td-agent/plugin_gems.rb
+++ b/td-agent/plugin_gems.rb
@@ -48,5 +48,6 @@ end
 if windows?
   download 'win32-eventlog', '0.6.7'
   download 'winevt_c', '0.8.1'
+  download 'fluent-plugin-parser-winevt_xml', '0.2.3.rc1'
   download 'fluent-plugin-windows-eventlog', '0.7.1.rc1'
 end


### PR DESCRIPTION
We should bundle fluent-plugin-parser-winevt_xml to parse XML style Windows EventLog events.
This should be needed for restoring previous version omnibus-td-agent installer behavior.

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>