### PR TITLE
Use nokogiri 1.10.10

### DIFF
--- a/td-agent/debian/copyright
+++ b/td-agent/debian/copyright
@@ -157,7 +157,7 @@ Files: downloads/plugin_gems/25-fluent-plugin-systemd-1.0.2.gem
 Copyright: Ed Robinson
 License: Apache-2.0
 
-Files: downloads/plugin_gems/26-nokogiri-1.11.0.rc2.gem
+Files: downloads/plugin_gems/26-nokogiri-1.10.10.gem
 Copyright: Aaron Patterson,Mike Dalessio,Yoko Harada,Tim Elliott,Akinori MUSHA,John Shahid,Lars Kanis
 License: MIT
 

--- a/td-agent/plugin_gems.rb
+++ b/td-agent/plugin_gems.rb
@@ -40,14 +40,14 @@ end
 
 # temporal solution for ruby 2.7
 if windows?
-  download "nokogiri", "1.11.0.rc2-x64-mingw32"
+  download "nokogiri", "1.10.10-x64-mingw32"
 else
-  download "nokogiri", "1.11.0.rc2"
+  download "nokogiri", "1.10.10"
 end
 
 if windows?
   download 'win32-eventlog', '0.6.7'
   download 'winevt_c', '0.8.1'
-  download 'fluent-plugin-parser-winevt_xml', '0.2.3.rc1'
-  download 'fluent-plugin-windows-eventlog', '0.7.1.rc1'
+  download 'fluent-plugin-parser-winevt_xml', '0.2.2'
+  download 'fluent-plugin-windows-eventlog', '0.7.0'
 end


### PR DESCRIPTION
Using nokogiri 1.11.0.rc2 is first aid to build with Ruby 2.7 on Windows.
We should use the stable version of nokogiri 1.10.10.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>