### PR TITLE
MSI: Use ENV['TD_AGENT_TOPDIR'] to specify install directory

### DIFF
--- a/td-agent/templates/opt/td-agent/share/td-agent.conf.tmpl
+++ b/td-agent/templates/opt/td-agent/share/td-agent.conf.tmpl
@@ -16,12 +16,20 @@
   auto_create_table
   <buffer>
     @type file
+<% if windows? %>
+    path "#{ENV['TD_AGENT_TOPDIR']}/var/log/<%= project_name %>/buffer/td"
+<% else %>
     path /var/log/<%= project_name %>/buffer/td
+<% end %>
   </buffer>
 
   <secondary>
     @type file
+<% if windows? %>
+    path "#{ENV['TD_AGENT_TOPDIR']}/var/log/<%= project_name %>/failed_records"
+<% else %>
     path /var/log/<%= project_name %>/failed_records
+<% end %>
   </secondary>
 </match>
 


### PR DESCRIPTION
On windows, /var/... may creates C:/var, so it should be
ENV['TD_AGENT_TOPDIR'] (typically c:/opt/td-agent) prepended.