### PR TITLE
MSI: support to enable delay start

### DIFF
--- a/td-agent/msi/source.wxs
+++ b/td-agent/msi/source.wxs
@@ -113,7 +113,7 @@
                   Return="check"
                   Impersonate="no" />
     <CustomAction Id="InstallFluentdWinSvc"
-                  ExeCommand="[PROJECTLOCATION]bin\td-agent.bat --reg-winsvc i --reg-winsvc-fluentdopt &quot;-c [PROJECTLOCATION]\etc\td-agent\td-agent.conf -o [PROJECTLOCATION]\td-agent.log&quot;"
+                  ExeCommand="[PROJECTLOCATION]bin\td-agent.bat --reg-winsvc i --reg-winsvc-delay-start --reg-winsvc-auto-start --reg-winsvc-fluentdopt &quot;-c [PROJECTLOCATION]\etc\td-agent\td-agent.conf -o [PROJECTLOCATION]\td-agent.log&quot;"
                   Directory="PROJECTLOCATION"
                   Execute="deferred"
                   Return="check"


### PR DESCRIPTION
In the previous version (4.0.0), we need start
Fluentd Windows Service(fluentdwinsvc) manually.

In this commit, use delay start which is supported in Fluentd 1.11.1.