### PR TITLE
Use URI.open instead of deprecated Kernel#open

### DIFF
--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -119,8 +119,8 @@ class DownloadTask
 
     ensure_directory(DOWNLOADS_DIR) do
       puts "Downloading #{filename}..."
-      open(url) do |in_file|
-        open(tmp_filename, "wb") do |out_file|
+      URI.open(url) do |in_file|
+        File.open(tmp_filename, "wb") do |out_file|
           out_file.write(in_file.read)
         end
       end


### PR DESCRIPTION
https://github.com/ruby/ruby/blob/ruby_2_7/NEWS#label-Stdlib+updates+-28outstanding+ones+only-29

Signed-off-by: Kohei Suzuki <eagletmt@gmail.com>