### PR TITLE
deb: drop needless prerm

### DIFF
--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -323,7 +323,7 @@ class BuildTask
         remove_needless_files
       end
 
-      debian_pkg_scripts = ["preinst", "postinst", "prerm", "postrm"]
+      debian_pkg_scripts = ["preinst", "postinst", "postrm"]
       debian_pkg_scripts.each do |script|
         CLEAN.include(File.join("..", "debian", script))
       end

--- a/td-agent/templates/package-scripts/td-agent/deb/prerm
+++ b/td-agent/templates/package-scripts/td-agent/deb/prerm
@@ -1,6 +1,0 @@
-#!/bin/sh
-set -e
-
-. /usr/share/debconf/confmodule
-
-#DEBHELPER#


### PR DESCRIPTION
It is useless because of source confmodule doesn't affects package
behavior.