### PR TITLE
Use win32-api v1.9.1

### DIFF
--- a/td-agent/core_gems.rb
+++ b/td-agent/core_gems.rb
@@ -18,7 +18,7 @@ if windows?
   download 'win32-ipc', '0.7.0'
   download 'win32-event', '0.6.3'
   download 'win32-service', '2.1.5'
-  download 'win32-api', '1.8.0-universal-mingw32'
+  download 'win32-api', '1.9.1-universal-mingw32'
   download 'windows-pr', '1.2.6'
   download 'windows-api', '0.4.4'
 end


### PR DESCRIPTION
Otherwise, when using Ruby 2.7, users get the following warnings:

<details>

```
~/Documents/GitHub/fluentd/vendor/bundle/ruby/2.7.0/gems/windows-api-0.4.4/lib/windows/api.rb:333: warning: rb_check_safe_obj will be removed in Ruby 3.0
~/Documents/GitHub/fluentd/vendor/bundle/ruby/2.7.0/gems/windows-api-0.4.4/lib/windows/api.rb:333: warning: rb_check_safe_obj will be removed in Ruby 3.0
~/Documents/GitHub/fluentd/vendor/bundle/ruby/2.7.0/gems/windows-api-0.4.4/lib/windows/api.rb:333: warning: rb_check_safe_obj will be removed in Ruby 3.0
~/Documents/GitHub/fluentd/vendor/bundle/ruby/2.7.0/gems/windows-api-0.4.4/lib/windows/api.rb:333: warning: rb_check_safe_obj will be removed in Ruby 3.0
~/Documents/GitHub/fluentd/vendor/bundle/ruby/2.7.0/gems/windows-api-0.4.4/lib/windows/api.rb:350: warning: rb_check_safe_obj will be removed in Ruby 3.0
~/Documents/GitHub/fluentd/vendor/bundle/ruby/2.7.0/gems/windows-api-0.4.4/lib/windows/api.rb:350: warning: rb_check_safe_obj will be removed in Ruby 3.0
~/Documents/GitHub/fluentd/vendor/bundle/ruby/2.7.0/gems/windows-api-0.4.4/lib/windows/api.rb:357: warning: rb_check_safe_obj will be removed in Ruby 3.0
~/Documents/GitHub/fluentd/vendor/bundle/ruby/2.7.0/gems/windows-api-0.4.4/lib/windows/api.rb:357: warning: rb_check_safe_obj will be removed in Ruby 3.0
~/Documents/GitHub/fluentd/vendor/bundle/ruby/2.7.0/gems/windows-api-0.4.4/lib/windows/api.rb:333: warning: rb_check_safe_obj will be removed in Ruby 3.0
<snip>
```
</details>

win32-api v1.9.1 should fix this warnings with: https://github.com/cosmo0920/win32-api/pull/49


Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>