### PR TITLE
travis: Try to use travis_retry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
   - env: RAKE_TASK="yum:build" YUM_TARGETS="centos-8" ARCHIVE_BASE="centos-8" PACKAGE_SYSTEM=yum
   - env: RAKE_TASK="yum:build" YUM_TARGETS="amazonlinux-2" ARCHIVE_BASE="amazonlinux-2" PACKAGE_SYSTEM=yum
 script:
-  - rake $RAKE_TASK
+  - travis_retry rake $RAKE_TASK
 before_deploy:
   - export RELEASE_DIRECTORY="td-agent/${PACKAGE_SYSTEM}/repositories/"
   - tar cJvf package-${ARCHIVE_BASE}-arm64.tar.xz td-agent/${PACKAGE_SYSTEM}/repositories


### PR DESCRIPTION
This is because network error sometimes occurs in Travis.
This command should retry build step when error occurred.
But `travis_retry` is not perfect solution for #136. 

This seems to be Travis' network problem...:
```
ERROR:  Could not find a valid gem 'fluent-plugin-systemd' (= 1.0.2), here is why:
          Unable to download data from https://rubygems.org/ - no such name (https://rubygems.org/quick/Marshal.4.8/fluent-plugin-systemd-1.0.2.gemspec.rz)
ERROR:  Possible alternatives: fluent-plugin-systemd
ERROR:  Could not find a valid gem 'fluent-plugin-systemd-1.0.2.gem' (>= 0) in any repository
```

ref: https://travis-ci.com/github/fluent-plugins-nursery/td-agent-builder/jobs/361133664#L1039
 
Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>