### PR TITLE
deb: update tmpl path

### DIFF
--- a/td-agent/templates/package-scripts/td-agent/deb/postinst
+++ b/td-agent/templates/package-scripts/td-agent/deb/postinst
@@ -69,7 +69,7 @@ case "$1" in
         add_system_user
         add_directories
         fixperms
-        update_conffile /etc/<%= project_name %>/<%= project_name %>.conf /etc/<%= project_name %>/<%= project_name %>.conf.tmpl
+        update_conffile /etc/<%= project_name %>/<%= project_name %>.conf /opt/<%= project_name %>/share/<%= project_name %>.conf.tmpl
         ;;
     abort-upgrade|abort-deconfigure|abort-remove)
         :


### PR DESCRIPTION
Closes: #145

Since TD Agent 4.0.0, tmpl path was changed from
/etc/td-agent/td-agent.conf.tmpl.
It is a good manner not to put .tmpl under /etc, but
path of new .tmpl is not updated.
It caused a bug that re-install package fails because of
the following error:

  Updating conffile /etc/td-agent/td-agent.conf ...
  cp: cannot stat '/etc/td-agent/td-agent.conf.tmpl': No such file or directory
  dpkg: error processing package td-agent (--configure):
   installed td-agent package post-installation script subprocess returned error exit status 1
  Errors were encountered while processing:
   td-agent
  E: Sub-process /usr/bin/dpkg returned an error code (1)