### PR TITLE
msi: Prevent to generate needless files on Windows

### DIFF
--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -380,10 +380,12 @@ class BuildTask
       task :td_agent_config do
         configs = [
           "etc/td-agent/td-agent.conf",
-          "opt/td-agent/share/td-agent.conf.tmpl",
           "etc/logrotate.d/td-agent",
-          "opt/td-agent/share/td-agent-ruby.conf"
         ]
+        configs.concat([
+          "opt/td-agent/share/td-agent.conf.tmpl",
+          "opt/td-agent/share/td-agent-ruby.conf"
+        ]) unless windows?
         configs.each do |config|
           src = template_path(config)
           dest = File.join(STAGING_DIR, config)


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>

![td-agent4-no-nested-opt](https://user-images.githubusercontent.com/700876/89163863-3c8ca780-d5b1-11ea-86c7-e3f16070e8c6.png)

This patch also prevent to create nested opt directory on msi package.

Fixes #150.
Closes #156 in favor of this PR.