### PR TITLE
MSI: set TD_AGENT_TOPDIR correctly

### DIFF
--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -379,15 +379,18 @@ class BuildTask
       desc "Create td-agent configuration files from template"
       task :td_agent_config do
         configs = [
-          "etc/td-agent/td-agent.conf",
-          "etc/logrotate.d/td-agent",
+          "etc/td-agent/td-agent.conf"
         ]
         configs.concat([
-          "opt/td-agent/share/td-agent.conf.tmpl",
-          "opt/td-agent/share/td-agent-ruby.conf"
+          "etc/logrotate.d/td-agent",
+          "opt/td-agent/share/td-agent-ruby.conf",
+          "opt/td-agent/share/td-agent.conf.tmpl"
         ]) unless windows?
         configs.each do |config|
           src = template_path(config)
+          if config == "etc/td-agent/td-agent.conf"
+            src = template_path("opt/td-agent/share/td-agent.conf.tmpl")
+          end
           dest = File.join(STAGING_DIR, config)
           render_template(dest, src, template_params)
         end

--- a/td-agent/msi/source.wxs
+++ b/td-agent/msi/source.wxs
@@ -71,6 +71,13 @@
         <Shortcut Id="ApplicationShortcut" Name="!(loc.ProductName) Command Prompt" Description="Open !(loc.ProductName) Command Prompt" Target="[SystemFolder]cmd.exe" Arguments='/k "[PROJECTLOCATION]td-agent-prompt.bat"' WorkingDirectory="PROJECTLOCATION" />
         <RemoveFolder Id="ApplicationProgramFolder" On="uninstall" />
         <RegistryValue Root="HKCU" Key="Software\[Manufacturer]\[ProductName]" Name="installed" Type="integer" Value="1" KeyPath="yes" />
+        <Environment Id="ProjectLocationDirForConf"
+                     Action="set"
+                     Permanent="no"
+                     Part="all"
+                     System="yes"
+                     Name="TD_AGENT_TOPDIR"
+                     Value="[PROJECTLOCATION]"/>
       </Component>
     </DirectoryRef>
 


### PR DESCRIPTION
Use TD_AGENT_TOPDIR in td-agent.conf on Windows
which is generated from .tmpl file.

and logrotate.d is not needed, so it was removed

NOTE: Alter installed at once, TD_AGENT_TOPDIR
is not refrected immediately.