### PR TITLE
MSI: remove needless separator

### DIFF
--- a/td-agent/msi/source.wxs
+++ b/td-agent/msi/source.wxs
@@ -120,7 +120,7 @@
                   Return="check"
                   Impersonate="no" />
     <CustomAction Id="InstallFluentdWinSvc"
-                  ExeCommand="[PROJECTLOCATION]bin\td-agent.bat --reg-winsvc i --reg-winsvc-delay-start --reg-winsvc-auto-start --reg-winsvc-fluentdopt &quot;-c [PROJECTLOCATION]\etc\td-agent\td-agent.conf -o [PROJECTLOCATION]\td-agent.log&quot;"
+                  ExeCommand="[PROJECTLOCATION]bin\td-agent.bat --reg-winsvc i --reg-winsvc-delay-start --reg-winsvc-auto-start --reg-winsvc-fluentdopt &quot;-c [PROJECTLOCATION]etc\td-agent\td-agent.conf -o [PROJECTLOCATION]td-agent.log&quot;"
                   Directory="PROJECTLOCATION"
                   Execute="deferred"
                   Return="check"


### PR DESCRIPTION
Before:
 -c opt\\td-agent\\\\etc\\td-agent\\td-agent.conf
 -o opt\\td-agent\\\\td-agent.log

After:
 -c opt\\td-agent\\etc\\td-agent\\td-agent.conf
 -o opt\\td-agent\\td-agent.log