### PR TITLE
rpm: set PAGE_SIZE=65536 on CentOS 7/8 aarch64

### DIFF
--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -525,6 +525,14 @@ class BuildTask
     configure_opts = [
       "--prefix=#{install_prefix}",
     ]
+    if ENV["TD_AGENT_STAGING_PATH"] and
+      (ENV["TD_AGENT_STAGING_PATH"].end_with?("el8.aarch64") or
+       ENV["TD_AGENT_STAGING_PATH"].end_with?("el7.aarch64"))
+      # NOTE: There is a case that PAGE_SIZE detection on
+      # CentOS 7 CentOS 8 with aarch64 AWS ARM instance.
+      # So, explicitly set PAGE_SIZE by with-lg-page 16 (2^16 = 65536)
+      configure_opts.concat(["--with-lg-page=16"])
+    end
     cd(source_dir) do
       sh("./configure", *configure_opts)
       sh("make", "install", "-j#{Etc.nprocessors}", "DESTDIR=#{STAGING_DIR}")


### PR DESCRIPTION
Closes: #176

Arm64 with Ubuntu/AL2 and x86_64 with all OSes use 4096 page size but
Arm64 with CentOS uses 65536 page size.

So, by specifying --with-lg-size=16, explicitly set PAGE_SIZE=65536
on such environment.

This commit fixes the following errors.

 fluentd[15556]: <jemalloc>: Unsupported system page size
 fluentd[15556]: <jemalloc>: Unsupported system page size
 fluentd[15556]: [FATAL] failed to allocate memory