### PR TITLE
macOS: Prelimitary build on GitHub Actions

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,15 @@
+name: macOS
+on:
+  push:
+  pull_request:
+jobs:
+  build:
+    name: Build
+    strategy:
+      fail-fast: false
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Build
+        run: |
+          rake build:all

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,4 +12,6 @@ jobs:
       - uses: actions/checkout@master
       - name: Build
         run: |
-          rake build:all
+          sudo mkdir /opt/td-agent
+          sudo chown $(whoami) /opt/td-agent
+          rake build:all TD_AGENT_STAGING_PATH="$(pwd)/darwin/tmp"

--- a/lib/gems_parser.rb
+++ b/lib/gems_parser.rb
@@ -9,6 +9,10 @@ class GemsParser
     /mswin|mingw/ =~ RUBY_PLATFORM
   end
 
+  def self.macos?
+    /darwin/ =~ RUBY_PLATFORM
+  end
+
   def initialize
     @target_dir = nil
     @target_files = []

--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -59,6 +59,10 @@ def windows?
   GemsParser.windows?
 end
 
+def macos?
+  GemsParser.macos?
+end
+
 def ensure_directory(dirname)
   mkdir_p(dirname) unless File.exists?(dirname)
   if block_given?
@@ -552,6 +556,11 @@ class BuildTask
       "--disable-install-doc",
       "--with-compress-debug-sections=no", # https://bugs.ruby-lang.org/issues/12934
     ]
+    if macos?
+     configure_opts.push("-C")
+     configure_opts.push("--with-openssl-dir=#{`brew --prefix openssl@1.1`.chomp!}")
+     configure_opts.push("--with-readline-dir=#{`brew --prefix readline`.chomp!}")
+    end
     cd(ruby_source_dir) do
       apply_ruby_patches
       sh("./configure", *configure_opts)


### PR DESCRIPTION
We'll create macOS package for Homebrew Formula or macOS installer (pkg/dmg).
So, the first step is `rake build:all` on macOS worker of GitHub Actions.