### PR TITLE
CI: remove needless --priviledged

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -60,7 +60,6 @@ jobs:
         run: |
           mkdir -p .bundle
           docker run \
-          --privileged \
           --rm \
           --tty \
           --volume ${PWD}:/fluentd:ro \
@@ -80,7 +79,6 @@ jobs:
         run: |
           mkdir -p .bundle
           docker run \
-          --privileged \
           --rm \
           --tty \
           --volume ${PWD}:/fluentd:ro \


### PR DESCRIPTION
--privileged is required to debootstrap command, so
It is no need to specify for install test/serverspec test cases.