### PR TITLE
rpm: remove needless .git directory

### DIFF
--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -997,6 +997,9 @@ class BuildTask
         rm_f(static_library)
       end
     end
+    Dir.glob("#{td_agent_staging_dir}/**/.git").each do |git_dir|
+      remove_files(git_dir, true)
+    end
   end
 end
 


### PR DESCRIPTION
This commit fixes W: cross-directory-hard-link rpmlint warning