### PR TITLE
github: apt: Fix an indentation on apt workflow

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -50,9 +50,9 @@ jobs:
           rake apt:build APT_TARGETS=${{ matrix.rake-job }}
       - name: Upload td-agent deb
         uses: actions/upload-artifact@master
-          with:
-            name: packages-${{ matrix.rake-job }}
-            path: td-agent/apt/repositories
+        with:
+          name: packages-${{ matrix.rake-job }}
+          path: td-agent/apt/repositories
       - name: Upload td-agent-apt-source deb
         uses: actions/upload-artifact@master
         with:


### PR DESCRIPTION
`with` clause should be same indentation level for `uses` or `name`

Otherwise, apt workflow is broken.... :cry:

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>