### PR TITLE
td-agent: msi: serverspec: Remove find_installed_gem.ps1 workaround

### DIFF
--- a/td-agent/msi/serverspec-test.ps1
+++ b/td-agent/msi/serverspec-test.ps1
@@ -10,9 +10,6 @@ $ENV:PATH="C:\\opt\\td-agent\\bin;" + $ENV:PATH
 td-agent --version
 
 td-agent-gem install --no-document serverspec
-$application = (Get-ChildItem -Path "c:\\opt" -Filter "find_installed_application.ps1" -Recurse -Name)
-$destination = (Get-Item (Join-Path "c:\\opt" $application)).DirectoryName
-Copy-Item "C:\\fluentd\\serverspec\\find_installed_gem.ps1" $destination
 $ENV:INSTALLATION_TEST=$TRUE
 cd C:\fluentd; rake serverspec:windows
 


### PR DESCRIPTION
Specinfra v2.82.20 includes this change:
https://github.com/mizzy/specinfra/commit/73ee0f20ad9f1484da2865ba53945f7563119cb5

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>