### PR TITLE
deb rpm: show td-agent and fluentd version at the same time

### DIFF
--- a/td-agent/templates/usr/sbin/td-agent.erb
+++ b/td-agent/templates/usr/sbin/td-agent.erb
@@ -4,4 +4,12 @@ ENV["GEM_PATH"]="<%= gem_install_path %>/"
 ENV["FLUENT_CONF"]="/etc/<%= project_name %>/<%= project_name %>.conf"
 ENV["FLUENT_PLUGIN"]="/etc/<%= project_name %>/plugin"
 ENV["FLUENT_SOCKET"]="/var/run/<%= project_name %>/<%= project_name %>.sock"
+if ARGV.include?("--version")
+  require "<%= install_path %>/share/config"
+  Dir.glob("<%= install_path %>/lib/ruby/**/bundler/**/fluent/version.rb").each do |v|
+    require v.delete_suffix(".rb")
+  end
+  puts "td-agent #{PACKAGE_VERSION} fluentd #{Fluent::VERSION} (#{FLUENTD_REVISION})"
+  exit 0
+end
 load "<%= install_path %>/bin/fluentd"


### PR DESCRIPTION
Example:

  $ /usr/sbin/td-agent --version
  td-agent 4.0.1 fluentd 1.11.2 (2f80f6cf0a4aa44b9795cd6a66894a6b8fa70d06)