### PR TITLE
msi: show td-agent and fluentd version

### DIFF
--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -519,6 +519,7 @@ class BuildTask
         cp("msi/assets/td-agent-post-install.bat", staging_bindir)
         cp("msi/assets/td-agent.bat", staging_bindir)
         cp("msi/assets/td-agent-gem.bat", staging_bindir)
+        cp("msi/assets/td-agent-version.rb", staging_bindir)
       end
 
       desc "Create systemd unit file for Red Hat like systems"

--- a/td-agent/msi/assets/td-agent-version.rb
+++ b/td-agent/msi/assets/td-agent-version.rb
@@ -1,0 +1,6 @@
+td_agent_config = File.expand_path(File.join(File.dirname(__FILE__), "../share/config"))
+require td_agent_config
+Dir.glob("#{ENV['TD_AGENT_TOPDIR'].gsub(/\\/, '/')}/lib/ruby/**/bundler/**/fluent/version.rb").each do |v|
+  require v.delete_suffix(".rb")
+end
+puts "td-agent #{PACKAGE_VERSION} fluentd #{Fluent::VERSION} (#{FLUENTD_REVISION})"

--- a/td-agent/msi/assets/td-agent.bat
+++ b/td-agent/msi/assets/td-agent.bat
@@ -7,7 +7,9 @@ set TD_AGENT_VERSION=%TD_AGENT_TOPDIR%\bin\td-agent-version.rb
 for %%p in (%*) do (
     if "%%p"=="--version" (
         ruby "%TD_AGENT_VERSION%"
-        exit 0
+        gogo last
     )
 )
 "%TD_AGENT_TOPDIR%\bin\fluentd" %*
+
+:last

--- a/td-agent/msi/assets/td-agent.bat
+++ b/td-agent/msi/assets/td-agent.bat
@@ -3,4 +3,11 @@ set TD_AGENT_TOPDIR=%~dp0\..
 set PATH="%~dp0";%PATH%
 set FLUENT_CONF=%TD_AGENT_TOPDIR%\etc\td-agent\td-agent.conf
 set FLUENT_PLUGIN=%TD_AGENT_TOPDIR%\etc\td-agent\plugin
+set TD_AGENT_VERSION=%TD_AGENT_TOPDIR%\bin\td-agent-version.rb
+for %%p in (%*) do (
+    if "%%p"=="--version" (
+        ruby "%TD_AGENT_VERSION%"
+        exit 0
+    )
+)
 "%TD_AGENT_TOPDIR%\bin\fluentd" %*


### PR DESCRIPTION
Example:

  > .\td-agent.bat --version
  td-agent 4.0.1 fluentd 1.11.2 (2f80f6cf0a4aa44b9795cd6a66894a6b8fa70d06)