### PR TITLE
amazonlinux-2: Suppress non-standard-uid/gid warnings

### DIFF
--- a/td-agent/yum/rpmlint.config
+++ b/td-agent/yum/rpmlint.config
@@ -43,3 +43,6 @@ addFilter("W: only-non-binary-in-usr-lib")
 addFilter("W: service-default-enabled")
 # It is intended to ignore false positive line in /etc/init.d/td-agent (/var/lock/subsys/${prog})
 addFilter("W: incoherent-subsys")
+# It is intended to ignore non-standard-uid/gid on AmazonLinux 2
+addFilter("W: non-standard-uid")
+addFilter("W: non-standard-gid")


### PR DESCRIPTION
Amazon Linux 2's rpm lint complains the following:

<details>

```
td-agent.x86_64: W: non-standard-uid /etc/td-agent/plugin td-agent
A file in this package is owned by a non standard user. Standard users are:
abrt, activemq, adm, aeolus, amandabackup, apache, arpwatch, ats, avahi,
avahi-autoipd, bacula, beagleindex, bin, ceilometer, ceph, cimsrvr, cinder,
clamav, condor, cyrus, daemon, dbus, desktop, dhcpd, distcache, dovecot,
elasticsearch, exim, fax, frontpage, ftp, games, gdm, glance, gopher,
hacluster, haldaemon, halt, haproxy, heat, hsqldb, ident, jboss, jbosson-
agent, jetty, jonas, katello, keystone, ldap, lp, luci, mail, mailman,
mailnull, majordomo, mongodb, myproxy, mysql, named, netdump, news, nfsnobody,
nobody, nocpulse, nova, nscd, nslcd, ntp, nut, operator, oprofile, ovirt,
ovirtagent, pegasus, piranha, pkiuser, polkituser, postfix, postgres, prelude-
manager, privoxy, pulse, puppet, pvm, qemu, quagga, quantum, radiusd, radvd,
retrace, rhevm, ricci, root, rpc, rpcuser, rpm, rtkit, sabayon, saned,
sanlock, shutdown, smmsp, snortd, squid, sshd, stap-server, swift, sync,
systemd-journal-gateway, systemd-network, systemd-resolve, tcpdump, tomcat,
tss, usbmuxd, uucp, vcsa, vdsm, vhostmd, wallaby, webalizer, wnn, xfs.

td-agent.x86_64: W: non-standard-gid /etc/td-agent/plugin td-agent
A file in this package is owned by a non standard group. Standard groups are:
abrt, activemq, adm, aeolus, apache, arpwatch, ats, audio, avahi, avahi-
autoipd, bacula, beagleindex, bin, cdrom, ceilometer, ceph, cimsrvr, cinder,
clamav, condor, console, daemon, dbus, desktop, dhcpd, dialout, dip, disk,
distcache, dovecot, elasticsearch, exim, fax, floppy, frontpage, ftp, games,
gdm, glance, gopher, haclient, haldaemon, haproxy, heat, hsqldb, ident, jboss,
jbosson, jetty, jonas, katello, keystone, kmem, kvm, ldap, lock, lp, luci,
mail, mailman, mailnull, majordomo, man, mem, mock, mongodb, myproxy, mysql,
named, netdump, news, nfsnobody, nobody, nocpulse, nova, nscd, ntp, nut,
oprofile, ovirt, ovirtagent, pegasus, piranha, pkiuser, polkituser, popusers,
postdrop, postfix, postgres, pppusers, prelude-manager, privoxy, pulse,
puppet, pvm, qemu, quagga, quaggavt, quantum, radiusd, radvd, realtime,
retrace, rhevm, ricci, root, rpc, rpcuser, rpm, rtkit, sabayon, saned,
sanlock, saslauth, screen, slipusers, slocate, smmsp, snortd, squid, sshd,
stap-server, stapdev, stapsys, stapusr, swift, sys, systemd-journal, systemd-
journal-gateway, systemd-network, systemd-resolve, tape, tcpdump, tomcat, tss,
tty, usbmuxd, users, utempter, utmp, uucp, vcsa, vhostmd, video, wallaby,
wbpriv, webalizer, wheel, wine, wnn, xfs.

td-agent.x86_64: W: non-standard-uid /var/log/td-agent/buffer td-agent
A file in this package is owned by a non standard user. Standard users are:
abrt, activemq, adm, aeolus, amandabackup, apache, arpwatch, ats, avahi,
avahi-autoipd, bacula, beagleindex, bin, ceilometer, ceph, cimsrvr, cinder,
clamav, condor, cyrus, daemon, dbus, desktop, dhcpd, distcache, dovecot,
elasticsearch, exim, fax, frontpage, ftp, games, gdm, glance, gopher,
hacluster, haldaemon, halt, haproxy, heat, hsqldb, ident, jboss, jbosson-
agent, jetty, jonas, katello, keystone, ldap, lp, luci, mail, mailman,
mailnull, majordomo, mongodb, myproxy, mysql, named, netdump, news, nfsnobody,
nobody, nocpulse, nova, nscd, nslcd, ntp, nut, operator, oprofile, ovirt,
ovirtagent, pegasus, piranha, pkiuser, polkituser, postfix, postgres, prelude-
manager, privoxy, pulse, puppet, pvm, qemu, quagga, quantum, radiusd, radvd,
retrace, rhevm, ricci, root, rpc, rpcuser, rpm, rtkit, sabayon, saned,
sanlock, shutdown, smmsp, snortd, squid, sshd, stap-server, swift, sync,
systemd-journal-gateway, systemd-network, systemd-resolve, tcpdump, tomcat,
tss, usbmuxd, uucp, vcsa, vdsm, vhostmd, wallaby, webalizer, wnn, xfs.

td-agent.x86_64: W: non-standard-gid /var/log/td-agent/buffer td-agent
A file in this package is owned by a non standard group. Standard groups are:
abrt, activemq, adm, aeolus, apache, arpwatch, ats, audio, avahi, avahi-
autoipd, bacula, beagleindex, bin, cdrom, ceilometer, ceph, cimsrvr, cinder,
clamav, condor, console, daemon, dbus, desktop, dhcpd, dialout, dip, disk,
distcache, dovecot, elasticsearch, exim, fax, floppy, frontpage, ftp, games,
gdm, glance, gopher, haclient, haldaemon, haproxy, heat, hsqldb, ident, jboss,
jbosson, jetty, jonas, katello, keystone, kmem, kvm, ldap, lock, lp, luci,
mail, mailman, mailnull, majordomo, man, mem, mock, mongodb, myproxy, mysql,
named, netdump, news, nfsnobody, nobody, nocpulse, nova, nscd, ntp, nut,
oprofile, ovirt, ovirtagent, pegasus, piranha, pkiuser, polkituser, popusers,
postdrop, postfix, postgres, pppusers, prelude-manager, privoxy, pulse,
puppet, pvm, qemu, quagga, quaggavt, quantum, radiusd, radvd, realtime,
retrace, rhevm, ricci, root, rpc, rpcuser, rpm, rtkit, sabayon, saned,
sanlock, saslauth, screen, slipusers, slocate, smmsp, snortd, squid, sshd,
stap-server, stapdev, stapsys, stapusr, swift, sys, systemd-journal, systemd-
journal-gateway, systemd-network, systemd-resolve, tape, tcpdump, tomcat, tss,
tty, usbmuxd, users, utempter, utmp, uucp, vcsa, vhostmd, video, wallaby,
wbpriv, webalizer, wheel, wine, wnn, xfs.

td-agent.x86_64: W: non-standard-uid /etc/td-agent td-agent
A file in this package is owned by a non standard user. Standard users are:
abrt, activemq, adm, aeolus, amandabackup, apache, arpwatch, ats, avahi,
avahi-autoipd, bacula, beagleindex, bin, ceilometer, ceph, cimsrvr, cinder,
clamav, condor, cyrus, daemon, dbus, desktop, dhcpd, distcache, dovecot,
elasticsearch, exim, fax, frontpage, ftp, games, gdm, glance, gopher,
hacluster, haldaemon, halt, haproxy, heat, hsqldb, ident, jboss, jbosson-
agent, jetty, jonas, katello, keystone, ldap, lp, luci, mail, mailman,
mailnull, majordomo, mongodb, myproxy, mysql, named, netdump, news, nfsnobody,
nobody, nocpulse, nova, nscd, nslcd, ntp, nut, operator, oprofile, ovirt,
ovirtagent, pegasus, piranha, pkiuser, polkituser, postfix, postgres, prelude-
manager, privoxy, pulse, puppet, pvm, qemu, quagga, quantum, radiusd, radvd,
retrace, rhevm, ricci, root, rpc, rpcuser, rpm, rtkit, sabayon, saned,
sanlock, shutdown, smmsp, snortd, squid, sshd, stap-server, swift, sync,
systemd-journal-gateway, systemd-network, systemd-resolve, tcpdump, tomcat,
tss, usbmuxd, uucp, vcsa, vdsm, vhostmd, wallaby, webalizer, wnn, xfs.

td-agent.x86_64: W: non-standard-gid /etc/td-agent td-agent
A file in this package is owned by a non standard group. Standard groups are:
abrt, activemq, adm, aeolus, apache, arpwatch, ats, audio, avahi, avahi-
autoipd, bacula, beagleindex, bin, cdrom, ceilometer, ceph, cimsrvr, cinder,
clamav, condor, console, daemon, dbus, desktop, dhcpd, dialout, dip, disk,
distcache, dovecot, elasticsearch, exim, fax, floppy, frontpage, ftp, games,
gdm, glance, gopher, haclient, haldaemon, haproxy, heat, hsqldb, ident, jboss,
jbosson, jetty, jonas, katello, keystone, kmem, kvm, ldap, lock, lp, luci,
mail, mailman, mailnull, majordomo, man, mem, mock, mongodb, myproxy, mysql,
named, netdump, news, nfsnobody, nobody, nocpulse, nova, nscd, ntp, nut,
oprofile, ovirt, ovirtagent, pegasus, piranha, pkiuser, polkituser, popusers,
postdrop, postfix, postgres, pppusers, prelude-manager, privoxy, pulse,
puppet, pvm, qemu, quagga, quaggavt, quantum, radiusd, radvd, realtime,
retrace, rhevm, ricci, root, rpc, rpcuser, rpm, rtkit, sabayon, saned,
sanlock, saslauth, screen, slipusers, slocate, smmsp, snortd, squid, sshd,
stap-server, stapdev, stapsys, stapusr, swift, sys, systemd-journal, systemd-
journal-gateway, systemd-network, systemd-resolve, tape, tcpdump, tomcat, tss,
tty, usbmuxd, users, utempter, utmp, uucp, vcsa, vhostmd, video, wallaby,
wbpriv, webalizer, wheel, wine, wnn, xfs.

td-agent.x86_64: W: non-standard-uid /tmp/td-agent td-agent
A file in this package is owned by a non standard user. Standard users are:
abrt, activemq, adm, aeolus, amandabackup, apache, arpwatch, ats, avahi,
avahi-autoipd, bacula, beagleindex, bin, ceilometer, ceph, cimsrvr, cinder,
clamav, condor, cyrus, daemon, dbus, desktop, dhcpd, distcache, dovecot,
elasticsearch, exim, fax, frontpage, ftp, games, gdm, glance, gopher,
hacluster, haldaemon, halt, haproxy, heat, hsqldb, ident, jboss, jbosson-
agent, jetty, jonas, katello, keystone, ldap, lp, luci, mail, mailman,
mailnull, majordomo, mongodb, myproxy, mysql, named, netdump, news, nfsnobody,
nobody, nocpulse, nova, nscd, nslcd, ntp, nut, operator, oprofile, ovirt,
ovirtagent, pegasus, piranha, pkiuser, polkituser, postfix, postgres, prelude-
manager, privoxy, pulse, puppet, pvm, qemu, quagga, quantum, radiusd, radvd,
retrace, rhevm, ricci, root, rpc, rpcuser, rpm, rtkit, sabayon, saned,
sanlock, shutdown, smmsp, snortd, squid, sshd, stap-server, swift, sync,
systemd-journal-gateway, systemd-network, systemd-resolve, tcpdump, tomcat,
tss, usbmuxd, uucp, vcsa, vdsm, vhostmd, wallaby, webalizer, wnn, xfs.

td-agent.x86_64: W: non-standard-gid /tmp/td-agent td-agent
A file in this package is owned by a non standard group. Standard groups are:
abrt, activemq, adm, aeolus, apache, arpwatch, ats, audio, avahi, avahi-
autoipd, bacula, beagleindex, bin, cdrom, ceilometer, ceph, cimsrvr, cinder,
clamav, condor, console, daemon, dbus, desktop, dhcpd, dialout, dip, disk,
distcache, dovecot, elasticsearch, exim, fax, floppy, frontpage, ftp, games,
gdm, glance, gopher, haclient, haldaemon, haproxy, heat, hsqldb, ident, jboss,
jbosson, jetty, jonas, katello, keystone, kmem, kvm, ldap, lock, lp, luci,
mail, mailman, mailnull, majordomo, man, mem, mock, mongodb, myproxy, mysql,
named, netdump, news, nfsnobody, nobody, nocpulse, nova, nscd, ntp, nut,
oprofile, ovirt, ovirtagent, pegasus, piranha, pkiuser, polkituser, popusers,
postdrop, postfix, postgres, pppusers, prelude-manager, privoxy, pulse,
puppet, pvm, qemu, quagga, quaggavt, quantum, radiusd, radvd, realtime,
retrace, rhevm, ricci, root, rpc, rpcuser, rpm, rtkit, sabayon, saned,
sanlock, saslauth, screen, slipusers, slocate, smmsp, snortd, squid, sshd,
stap-server, stapdev, stapsys, stapusr, swift, sys, systemd-journal, systemd-
journal-gateway, systemd-network, systemd-resolve, tape, tcpdump, tomcat, tss,
tty, usbmuxd, users, utempter, utmp, uucp, vcsa, vhostmd, video, wallaby,
wbpriv, webalizer, wheel, wine, wnn, xfs.

td-agent.x86_64: W: non-standard-uid /var/log/td-agent td-agent
A file in this package is owned by a non standard user. Standard users are:
abrt, activemq, adm, aeolus, amandabackup, apache, arpwatch, ats, avahi,
avahi-autoipd, bacula, beagleindex, bin, ceilometer, ceph, cimsrvr, cinder,
clamav, condor, cyrus, daemon, dbus, desktop, dhcpd, distcache, dovecot,
elasticsearch, exim, fax, frontpage, ftp, games, gdm, glance, gopher,
hacluster, haldaemon, halt, haproxy, heat, hsqldb, ident, jboss, jbosson-
agent, jetty, jonas, katello, keystone, ldap, lp, luci, mail, mailman,
mailnull, majordomo, mongodb, myproxy, mysql, named, netdump, news, nfsnobody,
nobody, nocpulse, nova, nscd, nslcd, ntp, nut, operator, oprofile, ovirt,
ovirtagent, pegasus, piranha, pkiuser, polkituser, postfix, postgres, prelude-
manager, privoxy, pulse, puppet, pvm, qemu, quagga, quantum, radiusd, radvd,
retrace, rhevm, ricci, root, rpc, rpcuser, rpm, rtkit, sabayon, saned,
sanlock, shutdown, smmsp, snortd, squid, sshd, stap-server, swift, sync,
systemd-journal-gateway, systemd-network, systemd-resolve, tcpdump, tomcat,
tss, usbmuxd, uucp, vcsa, vdsm, vhostmd, wallaby, webalizer, wnn, xfs.

td-agent.x86_64: W: non-standard-gid /var/log/td-agent td-agent
A file in this package is owned by a non standard group. Standard groups are:
abrt, activemq, adm, aeolus, apache, arpwatch, ats, audio, avahi, avahi-
autoipd, bacula, beagleindex, bin, cdrom, ceilometer, ceph, cimsrvr, cinder,
clamav, condor, console, daemon, dbus, desktop, dhcpd, dialout, dip, disk,
distcache, dovecot, elasticsearch, exim, fax, floppy, frontpage, ftp, games,
gdm, glance, gopher, haclient, haldaemon, haproxy, heat, hsqldb, ident, jboss,
jbosson, jetty, jonas, katello, keystone, kmem, kvm, ldap, lock, lp, luci,
mail, mailman, mailnull, majordomo, man, mem, mock, mongodb, myproxy, mysql,
named, netdump, news, nfsnobody, nobody, nocpulse, nova, nscd, ntp, nut,
oprofile, ovirt, ovirtagent, pegasus, piranha, pkiuser, polkituser, popusers,
postdrop, postfix, postgres, pppusers, prelude-manager, privoxy, pulse,
puppet, pvm, qemu, quagga, quaggavt, quantum, radiusd, radvd, realtime,
retrace, rhevm, ricci, root, rpc, rpcuser, rpm, rtkit, sabayon, saned,
sanlock, saslauth, screen, slipusers, slocate, smmsp, snortd, squid, sshd,
stap-server, stapdev, stapsys, stapusr, swift, sys, systemd-journal, systemd-
journal-gateway, systemd-network, systemd-resolve, tape, tcpdump, tomcat, tss,
tty, usbmuxd, users, utempter, utmp, uucp, vcsa, vhostmd, video, wallaby,
wbpriv, webalizer, wheel, wine, wnn, xfs.

```

 </details>

We use `td-agent` user and group intensionally.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>