### PR TITLE
centos8: use correct repo name

### DIFF
--- a/td-agent/yum/centos-8/Dockerfile
+++ b/td-agent/yum/centos-8/Dockerfile
@@ -24,7 +24,7 @@ ARG DEBUG
 
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
-  dnf install --enablerepo=PowerTools -y ${quiet} \
+  dnf install --enablerepo=powertools -y ${quiet} \
     make \
     gcc-c++ \
     ruby-devel  \

--- a/td-agent/yum/install-test.sh
+++ b/td-agent/yum/install-test.sh
@@ -32,7 +32,7 @@ case ${distribution} in
         DNF=yum
         ;;
       *)
-        DNF="dnf --enablerepo=PowerTools"
+        DNF="dnf --enablerepo=powertools"
         ENABLE_UPGRADE_TEST=0
         ;;
     esac

--- a/td-agent/yum/serverspec-test.sh
+++ b/td-agent/yum/serverspec-test.sh
@@ -37,7 +37,7 @@ case ${distribution} in
         DNF=yum
         ;;
       *)
-        DNF="dnf --enablerepo=PowerTools"
+        DNF="dnf --enablerepo=powertools"
         ENABLE_KAFKA_TEST=0
         ;;
     esac


### PR DESCRIPTION
e.g.

```
  # yum search --enablerepo=powertools libedit-devel
  Failed to set locale, defaulting to C.UTF-8
  Last metadata expiration check: 0:04:39 ago on Mon Dec 14 05:37:32 2020.
  =================================================== Name Exactly Matched: libedit-devel ====================================================
  libedit-devel.i686 : Development files for libedit
  libedit-devel.x86_64 : Development files for libedit
```
