### PR TITLE
Fix Windows Action

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Build
         run: |
           gem install serverspec
+          gem install bundler --no-document -v 2.2.0
           rake msi:build
       - name: Upload td-agent msi
         uses: actions/upload-artifact@master

--- a/td-agent/msi/Dockerfile
+++ b/td-agent/msi/Dockerfile
@@ -26,7 +26,7 @@ RUN @"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -I
 # Install toolchain
 RUN \
   choco install -y git wixtoolset 7zip && \
-  choco install -y msys2 --params /NoUpdate --version=20200816.0.0 && \
+  choco install -y msys2 --params /NoUpdate --version=20201109.0.0 && \
   choco install -y ruby && \
   refreshenv && \
   ridk install 3 && \


### PR DESCRIPTION
We need to install bundler before entering building process on Windows.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>