### PR TITLE
Create CentOS Stream 8 package and GitHub Actions

### DIFF
--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -11,20 +11,25 @@ jobs:
         label:
           - CentOS 7 x86_64
           - CentOS 8 x86_64
+          - CentOS Stream 8 x86_64
           - Amazon Linux 2 x86_64
         include:
           - label: CentOS 7 x86_64
             rake-job: centos-7
             test-docker-image: centos:7
+            centos-stream: false
           - label: CentOS 8 x86_64
             rake-job: centos-8
             test-docker-image: centos:8
+            centos-stream: false
           - label: CentOS Stream 8 x86_64
             rake-job: centos-stream-8
-            test-docker-image: td-agent-centos-stream-8
+            test-docker-image: centos:8
+            centos-stream: true
           - label: Amazon Linux 2 x86_64
             rake-job: amazonlinux-2
             test-docker-image: amazonlinux:2
+            centos-stream: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -47,6 +52,7 @@ jobs:
           --rm \
           --tty \
           --volume ${PWD}:/fluentd:ro \
+          --env CENTOS_STREAM=${{ matrix.centos-stream }} \
           ${{ matrix.test-docker-image }} \
           /fluentd/td-agent/yum/install-test.sh
       - name: Serverspec Test
@@ -56,5 +62,6 @@ jobs:
           --rm \
           --tty \
           --volume ${PWD}:/fluentd:ro \
+          --env CENTOS_STREAM=${{ matrix.centos-stream }} \
           ${{ matrix.test-docker-image }} \
           /fluentd/td-agent/yum/serverspec-test.sh

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -19,6 +19,9 @@ jobs:
           - label: CentOS 8 x86_64
             rake-job: centos-8
             test-docker-image: centos:8
+          - label: CentOS Stream 8 x86_64
+            rake-job: centos-stream-8
+            test-docker-image: td-agent-centos-stream-8
           - label: Amazon Linux 2 x86_64
             rake-job: amazonlinux-2
             test-docker-image: amazonlinux:2

--- a/lib/yum/build.sh
+++ b/lib/yum/build.sh
@@ -36,6 +36,9 @@ rpmbuild_options=
 distribution=$(cut -d " " -f 1 /etc/system-release | tr "A-Z" "a-z")
 if grep -q Linux /etc/system-release; then
   distribution_version=$(cut -d " " -f 4 /etc/system-release)
+elif grep -q Stream /etc/system-release; then
+  # ${version}-stream
+  distribution_version=$(cut -d " " -f 4 /etc/system-release)-$(cut -d " " -f 2 /etc/system-release | tr "[:upper:]" "[:lower:]")
 else
   distribution_version=$(cut -d " " -f 3 /etc/system-release)
 fi

--- a/td-agent/apt/serverspec-test.sh
+++ b/td-agent/apt/serverspec-test.sh
@@ -24,9 +24,9 @@ case ${code_name} in
 esac
 
 /usr/sbin/td-agent-gem install --no-document serverspec
-wget -qO - https://packages.confluent.io/deb/5.5/archive.key | apt-key add -
-echo "deb [arch=${architecture}] https://packages.confluent.io/deb/5.5 stable main" > /etc/apt/sources.list.d/confluent.list
-apt update && apt install -y confluent-community-2.12 ${java_jdk} netcat-openbsd
+wget -qO - https://packages.confluent.io/deb/6.0/archive.key | apt-key add -
+echo "deb [arch=${architecture}] https://packages.confluent.io/deb/6.0 stable main" > /etc/apt/sources.list.d/confluent.list
+apt update && apt install -y confluent-community-2.13 ${java_jdk} netcat-openbsd
 
 export KAFKA_OPTS=-Dzookeeper.4lw.commands.whitelist=ruok
 /usr/bin/zookeeper-server-start /etc/kafka/zookeeper.properties  &

--- a/td-agent/yum/centos-stream-8/Dockerfile
+++ b/td-agent/yum/centos-stream-8/Dockerfile
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ARG FROM=centos:8
+FROM ${FROM}
+
+COPY qemu-* /usr/bin/
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  dnf install centos-release-stream -y && \
+  dnf swap centos-{linux,stream}-repos -y && \
+  dnf distro-sync -y && \
+  dnf install --enablerepo=powertools -y ${quiet} \
+    make \
+    gcc-c++ \
+    ruby-devel  \
+    rubygems \
+    rubygem-rake \
+    rubygem-bundler \
+    libedit-devel \
+    ncurses-devel \
+    libyaml-devel \
+    git \
+    cyrus-sasl-devel \
+    nss-softokn-freebl-devel \
+    pkg-config \
+    rpm-build \
+    rpmdevtools \
+    redhat-rpm-config \
+    openssl-devel \
+    tar \
+    zlib-devel \
+    rpmlint && \
+    # enable multiplatform feature
+    gem install --no-document --install-dir /usr/share/gems bundler:2.2.0 && \
+  yum clean ${quiet} all

--- a/td-agent/yum/centos-stream-8/qemu-dummy-static
+++ b/td-agent/yum/centos-stream-8/qemu-dummy-static
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Do nothing. This exists only for not requiring qemu-aarch64-static copy.
+# Recent Debian (buster or later) and Ubuntu (18.10 or later) on amd64 hosts or
+# arm64 host don't require qemu-aarch64-static in Docker image. But old Debian
+# and Ubuntu hosts on amd64 require qemu-aarch64-static in Docker image.
+#
+# We use "COPY qemu* /usr/bin/" in Dockerfile. If we don't put any "qemnu*",
+# the "COPY" is failed. It means that we always require "qemu*" even if we
+# use recent Debian/Ubuntu or arm64 host. If we have this dummy "qemu*" file,
+# the "COPY" isn't failed. It means that we can copy "qemu*" only when we
+# need.
+#
+# See also "script" in dev/tasks/linux-packages/azure.linux.arm64.yml.
+# Azure Pipelines uses old Ubuntu (18.04).
+# So we need to put "qemu-aarch64-static" into this directory.

--- a/td-agent/yum/install-test.sh
+++ b/td-agent/yum/install-test.sh
@@ -26,10 +26,6 @@ case ${distribution} in
     ;;
   centos)
     case ${version} in
-      6)
-        DNF=yum
-        DISTRIBUTION_VERSION=${version}
-        ;;
       7)
         DNF=yum
         DISTRIBUTION_VERSION=${version}

--- a/td-agent/yum/install-test.sh
+++ b/td-agent/yum/install-test.sh
@@ -20,6 +20,7 @@ case ${distribution} in
     case ${version} in
       2)
         DNF=yum
+        DISTRIBUTION_VERSION=${version}
         ;;
     esac
     ;;
@@ -27,13 +28,24 @@ case ${distribution} in
     case ${version} in
       6)
         DNF=yum
+        DISTRIBUTION_VERSION=${version}
         ;;
       7)
         DNF=yum
+        DISTRIBUTION_VERSION=${version}
         ;;
       *)
         DNF="dnf --enablerepo=powertools"
         ENABLE_UPGRADE_TEST=0
+        if [ x"${CENTOS_STREAM}" == x"true" ]; then
+            echo "MIGRATE TO CENTOS STREAM"
+            ${DNF} install centos-release-stream -y && \
+                ${DNF} swap centos-{linux,stream}-repos -y && \
+                ${DNF} distro-sync -y
+            DISTRIBUTION_VERSION=${version}-stream
+        else
+            DISTRIBUTION_VERSION=${version}
+        fi
         ;;
     esac
     ;;
@@ -42,7 +54,7 @@ esac
 echo "INSTALL TEST"
 repositories_dir=/fluentd/td-agent/yum/repositories
 ${DNF} install -y \
-  ${repositories_dir}/${distribution}/${version}/x86_64/Packages/*.rpm
+  ${repositories_dir}/${distribution}/${DISTRIBUTION_VERSION}/x86_64/Packages/*.rpm
 
 td-agent --version
 
@@ -82,5 +94,5 @@ EOF
     ${DNF} update -y
     ${DNF} install -y td-agent
     ${DNF} install -y \
-           ${repositories_dir}/${distribution}/${version}/x86_64/Packages/*.rpm
+           ${repositories_dir}/${distribution}/${DISTRIBUTION_VERSION}/x86_64/Packages/*.rpm
 fi

--- a/td-agent/yum/serverspec-test.sh
+++ b/td-agent/yum/serverspec-test.sh
@@ -68,24 +68,24 @@ if [ $ENABLE_SERVERSPEC_TEST -eq 1 ]; then
 
     /usr/sbin/td-agent-gem install --no-document serverspec
     if [ $ENABLE_KAFKA_TEST -eq 1 ]; then
-        rpm --import https://packages.confluent.io/rpm/5.5/archive.key
+        rpm --import https://packages.confluent.io/rpm/6.0/archive.key
 
         cat >/etc/yum.repos.d/confluent.repo <<EOF;
 [Confluent.dist]
 name=Confluent repository (dist)
-baseurl=https://packages.confluent.io/rpm/5.5/${version}
+baseurl=https://packages.confluent.io/rpm/6.0/${version}
 gpgcheck=1
-gpgkey=https://packages.confluent.io/rpm/5.5/archive.key
+gpgkey=https://packages.confluent.io/rpm/6.0/archive.key
 enabled=1
 
 [Confluent]
 name=Confluent repository
-baseurl=https://packages.confluent.io/rpm/5.5
+baseurl=https://packages.confluent.io/rpm/6.0
 gpgcheck=1
-gpgkey=https://packages.confluent.io/rpm/5.5/archive.key
+gpgkey=https://packages.confluent.io/rpm/6.0/archive.key
 enabled=1
 EOF
-	yum update -y && yum install -y confluent-community-2.12 ${JAVA_JRE} nc
+	yum update -y && yum install -y confluent-community-2.13 ${JAVA_JRE} nc
 	export KAFKA_OPTS=-Dzookeeper.4lw.commands.whitelist=ruok
 	/usr/bin/zookeeper-server-start /etc/kafka/zookeeper.properties  &
 	n=1

--- a/td-agent/yum/serverspec-test.sh
+++ b/td-agent/yum/serverspec-test.sh
@@ -41,7 +41,6 @@ case ${distribution} in
         ;;
       *)
         DNF="dnf --enablerepo=powertools"
-        ENABLE_KAFKA_TEST=0
         if [ x"${CENTOS_STREAM}" == x"true" ]; then
             echo "MIGRATE TO CENTOS STREAM"
             ${DNF} install centos-release-stream -y && \

--- a/td-agent/yum/serverspec-test.sh
+++ b/td-agent/yum/serverspec-test.sh
@@ -30,11 +30,6 @@ case ${distribution} in
     ;;
   centos)
     case ${version} in
-      6)
-        DNF=yum
-        JAVA_JRE=java-1.8.0-openjdk
-        DISTRIBUTION_VERSION=${version}
-        ;;
       7)
         DNF=yum
         DISTRIBUTION_VERSION=${version}


### PR DESCRIPTION
confluent-community 2.13 supports CentOS/RHEL 8.
I also enabled CentOS/CentOS Stream 8 kafka test on serverspec.