### PR TITLE
Remove a workaround for broken protocol-http2

### DIFF
--- a/td-agent/Gemfile
+++ b/td-agent/Gemfile
@@ -22,10 +22,6 @@ gem "tzinfo-data", "1.2020.4"
 gem "async-http", "0.52.4"
 gem "fluentd", github: "fluent/fluentd", ref: FLUENTD_REVISION
 
-# https://github.com/socketry/protocol-http2/issues/6
-# protocol-http2 0.14.1 causes install error
-gem "protocol-http2", "0.14.0"
-
 # plugin gems
 
 gem "elasticsearch", "7.10.0"

--- a/td-agent/Gemfile.lock
+++ b/td-agent/Gemfile.lock
@@ -262,7 +262,6 @@ DEPENDENCIES
   nokogiri (= 1.10.10)
   oj (= 3.10.6)
   prometheus-client (= 0.9.0)
-  protocol-http2 (= 0.14.0)
   rake
   rdkafka (= 0.8.0)
   ruby-kafka (= 1.3.0)

--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -896,12 +896,6 @@ class BuildTask
     Dir.glob("**/*.gem").sort.each do |gem_path|
       @logger.debug("fetched gem path: <#{gem_path}>")
     end
-    # install protocol-http2 in advance not to install protocol-http2 0.14.1
-    gem_path = Dir.glob("#{relative_path}/protocol-http2-*.gem").first
-    unless gem_path
-      fail "Failed to install protocol-http2"
-    end
-    gem_install(gem_path)
     files = Dir.glob("#{relative_path}/*.gem").reject do |gem_path|
       gem_path.start_with?("#{relative_path}/protocol-http2-")
     end


### PR DESCRIPTION
Fixed version has been released:
https://rubygems.org/gems/protocol-http2/versions/0.14.2