### PR TITLE
First aid to avoid installing mismatched architecture's gems

### DIFF
--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -1032,6 +1032,7 @@ class LinuxPackageTask < PackageTask
       build_include_binaries_file
     end
 
+    # TODO: Probably debian related files should be built in the build container
     file @archive_name => [*repo_files, *@download_task.files, debian_copyright_file, debian_include_binaries_file] do
       build_archive
     end
@@ -1131,7 +1132,12 @@ EOS
         dest_downloads_dir = "#{@archive_base_name}/td-agent/downloads"
         dest_dir = "#{dest_downloads_dir}/#{File.dirname(relative_path)}"
         ensure_directory(dest_dir)
-        cp_r(path, dest_dir)
+        # TODO: When a tarball is create on a host OS that is different from a target,
+        # mismatched fat gems are included unexpectedly. To avoid it, remove gems from
+        # the archive and let the build container to download them.
+        # Although we should remove dependency to gems, they are still required to
+        # build debian/copyright. Probably it should be built in the build container.
+        cp_r(path, dest_dir) unless path.end_with?(".gem")
       end
       cp_r("td-agent/debian/copyright", "#{@archive_base_name}/td-agent/debian/copyright")
       sh("tar", "cvfz", @full_archive_name, @archive_base_name)


### PR DESCRIPTION
When a source tarball is created by a host OS that is different from
a target, fat gems for the host OS are brought to the build container
and installed. To avoid it, remove gems from a tarball so that
appropriate gems are downloaded by the build container.

Signed-off-by: Takuro Ashie <ashie@clear-code.com>