### PR TITLE
Use bundler to install gems

### DIFF
--- a/td-agent/Gemfile
+++ b/td-agent/Gemfile
@@ -9,7 +9,7 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 # core gems
 
 gem "rake"
-gem "bundler", "2.2.0"
+gem "bundler", BUNDLER_VERSION
 gem "cool.io", "1.7.0"
 gem "sigdump", "0.2.4"
 gem "http_parser.rb", "0.6.0"

--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -1032,6 +1032,7 @@ class LinuxPackageTask < PackageTask
       build_include_binaries_file
     end
 
+    # TODO: Probably debian related files should be built in the build container
     file @archive_name => [*repo_files, *@download_task.files, debian_copyright_file, debian_include_binaries_file] do
       build_archive
     end
@@ -1131,7 +1132,12 @@ EOS
         dest_downloads_dir = "#{@archive_base_name}/td-agent/downloads"
         dest_dir = "#{dest_downloads_dir}/#{File.dirname(relative_path)}"
         ensure_directory(dest_dir)
-        cp_r(path, dest_dir)
+        # TODO: When a tarball is create on a host OS that is different from a target,
+        # mismatched fat gems are included unexpectedly. To avoid it, remove gems from
+        # the archive and let the build container to download them.
+        # Although we should remove dependency to gems, they are still required to
+        # build debian/copyright. Probably it should be built in the build container.
+        cp_r(path, dest_dir) unless path.end_with?(".gem")
       end
       cp_r("td-agent/debian/copyright", "#{@archive_base_name}/td-agent/debian/copyright")
       sh("tar", "cvfz", @full_archive_name, @archive_base_name)

--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -397,7 +397,12 @@ class BuildTask
 
       desc "Install ruby gems"
       task :ruby_gems => [:"download:ruby_gems", :fluentd] do
-        install_gems(@download_task.files_ruby_gems)
+        gem_install("bundler", BUNDLER_VERSION)
+
+        gem_home = ENV["GEM_HOME"]
+        ENV["GEM_HOME"] = gem_staging_dir
+        sh(bundle_command, "_#{BUNDLER_VERSION}_", "install")
+        ENV["GEM_HOME"] = gem_home
       end
 
       desc "Install fluentd"
@@ -848,7 +853,7 @@ class BuildTask
     staging_dir
   end
 
-  def gem_install(gem_path)
+  def gem_install(gem_path, version = nil)
     ensure_directory(staging_bindir)
     ensure_directory(gem_staging_dir)
 
@@ -861,6 +866,10 @@ class BuildTask
       "--bindir", staging_bindir,
       gem_path
     ]
+    if version
+      gem_installation_command << "--version"
+      gem_installation_command << version
+    end
     if macos? && gem_path.include?("rdkafka")
       ENV["CPPFLAGS"] = "-I#{File.join(STAGING_DIR, install_prefix, 'include')}"
       ENV["LDFLAGS"] = "-L#{File.join(STAGING_DIR, install_prefix, 'lib')}"
@@ -874,34 +883,6 @@ class BuildTask
     sh(*gem_installation_command)
 
     ENV["GEM_HOME"] = gem_home
-  end
-
-  def install_gems(files)
-    ensure_directory(staging_bindir)
-    ensure_directory(gem_staging_dir)
-
-    Dir.chdir(DOWNLOADS_DIR) do
-      sh("gem", "fetch", "bundler","--version", "2.2.0")
-      gem_install(Dir.glob("bundler-*.gem").first)
-    end
-
-    relative_path = File.basename(DOWNLOADS_DIR)
-    @logger.debug("bundle config cache path: <#{relative_path}>")
-    gem_home = ENV["GEM_HOME"]
-    ENV["GEM_HOME"] = gem_staging_dir
-    sh(bundle_command, "_2.2.0_", "config", "set", "--local", "cache_path", relative_path)
-    sh(bundle_command, "_2.2.0_", "package", "--no-install")
-    ENV["GEM_HOME"] = gem_home
-
-    Dir.glob("**/*.gem").sort.each do |gem_path|
-      @logger.debug("fetched gem path: <#{gem_path}>")
-    end
-    files = Dir.glob("#{relative_path}/*.gem").reject do |gem_path|
-      gem_path.start_with?("#{relative_path}/protocol-http2-")
-    end
-    files.each do |gem_path|
-      gem_install(gem_path)
-    end
   end
 
   def install_jemalloc_license

--- a/td-agent/config.rb
+++ b/td-agent/config.rb
@@ -9,6 +9,8 @@ JEMALLOC_VERSION = "5.2.1"
 # https://www.openssl.org/source/
 OPENSSL_VERSION = "1.1.1i"
 
+BUNDLER_VERSION= "2.2.0"
+
 # https://www.ruby-lang.org/en/downloads/ (tar.gz)
 #BUNDLED_RUBY_VERSION = "2.5.8"
 #BUNDLED_RUBY_SOURCE_SHA256SUM = "6c0bdf07876c69811a9e7dc237c43d40b1cb6369f68e0e17953d7279b524ad9a"


### PR DESCRIPTION
Previous code uses `gem install` to install gems so that it ignores gem's versions described in Gemfile.lock. Because we are now using Gemfile, there is no reason not to use bundler to install gems.
In addition, this PR also prevent to install mismatched architecture's gem even if a source taball is created by a host OS that is different from a target.
