### PR TITLE
Remove needless ri documents in RubyInstaller (as of 2.7.2-1)

### DIFF
--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -963,6 +963,7 @@ class BuildTask
 
   def remove_needless_files
     remove_files("#{td_agent_staging_dir}/share/doc", true) # Contains only jemalloc.html
+    remove_files("#{td_agent_staging_dir}/share/ri", true)
     cd("#{gem_staging_dir}/cache") do
       remove_files("*.gem")
       remove_files("bundler", true)


### PR DESCRIPTION
The size of windows installer is decreased from 35MB to 26MB.