### PR TITLE
Explicitly install webrick 1.7.0

### DIFF
--- a/td-agent/Gemfile
+++ b/td-agent/Gemfile
@@ -21,6 +21,7 @@ gem "tzinfo", "2.0.4"
 gem "tzinfo-data", "1.2020.6"
 gem "async-http", "0.54.1"
 gem "fluentd", github: "fluent/fluentd", ref: FLUENTD_REVISION
+gem "webrick", "1.7.0"
 
 # plugin gems
 

--- a/td-agent/Gemfile.lock
+++ b/td-agent/Gemfile.lock
@@ -203,6 +203,7 @@ GEM
       tzinfo (>= 1.0.0)
     webhdfs (0.9.0)
       addressable
+    webrick (1.7.0)
     win32-api (1.9.2-universal-mingw32)
     win32-event (0.6.3)
       win32-ipc (>= 0.6.0)
@@ -276,6 +277,7 @@ DEPENDENCIES
   tzinfo (= 2.0.4)
   tzinfo-data (= 1.2020.6)
   webhdfs (= 0.9.0)
+  webrick (= 1.7.0)
   win32-api (= 1.9.2)
   win32-event (= 0.6.3)
   win32-eventlog (= 0.6.7)


### PR DESCRIPTION
Because of Ruby 3.0 dropped it.