### PR TITLE
Raise IPV4 priority for connecting rubygems.org

### DIFF
--- a/.github/workflows/apt-arm.yml
+++ b/.github/workflows/apt-arm.yml
@@ -28,7 +28,7 @@ jobs:
           sudo apt update
           sudo apt -V install ruby ruby-bundler ruby-serverspec
           sudo apt -V install qemu-user-static
-          sudo gem install bundler --no-document
+          sudo gem install bundler:2.2.9 --no-document
       - name: Build deb with Docker
         run: |
           cp /usr/bin/qemu-aarch64-static td-agent/apt/${{ matrix.rake-job }}/

--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt -V install ruby ruby-bundler ruby-serverspec
-          sudo gem install bundler --no-document
+          sudo gem install bundler:2.2.9 --no-document
       - name: Build deb with Docker
         run: |
           rake apt:build APT_TARGETS=${{ matrix.rake-job }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Build
         run: |
           gem install serverspec
-          gem install bundler --no-document
+          gem install bundler:2.2.9 --no-document
           rake msi:build
       - name: Upload td-agent msi
         uses: actions/upload-artifact@master

--- a/.github/workflows/yum-arm.yml
+++ b/.github/workflows/yum-arm.yml
@@ -30,7 +30,7 @@ jobs:
           sudo apt update
           sudo apt -V install ruby ruby-bundler ruby-serverspec
           sudo apt -V install qemu-user-static
-          sudo gem install bundler --no-document
+          sudo gem install bundler:2.2.9 --no-document
       - name: Build rpm with Docker
         run: |
           cp /usr/bin/qemu-aarch64-static td-agent/yum/${{ matrix.rake-job }}/

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt -V install ruby ruby-bundler ruby-serverspec
-          sudo gem install bundler --no-document
+          sudo gem install bundler:2.2.9 --no-document
       - name: Build rpm with Docker
         run: |
           rake yum:build YUM_TARGETS=${{ matrix.rake-job }}

--- a/td-agent/apt/debian-buster/Dockerfile
+++ b/td-agent/apt/debian-buster/Dockerfile
@@ -50,6 +50,8 @@ RUN \
     zlib1g-dev && \
   apt build-dep -y ruby && \
   apt clean && \
+  # raise IPv4 priority
+  sed -i'' -e 's,#precedence ::ffff:0:0/96  100,precedence ::ffff:0:0/96  100,' /etc/gai.conf && \
   # enable multiplatform feature
   gem install --no-document --install-dir /usr/share/rubygems-integration/all bundler && \
   rm -rf /var/lib/apt/lists/*

--- a/td-agent/apt/ubuntu-bionic/Dockerfile
+++ b/td-agent/apt/ubuntu-bionic/Dockerfile
@@ -49,6 +49,8 @@ RUN \
     zlib1g-dev && \
   apt build-dep -y ruby && \
   apt clean && \
+  # raise IPv4 priority
+  sed -i'' -e 's,#precedence ::ffff:0:0/96  100,precedence ::ffff:0:0/96  100,' /etc/gai.conf && \
   # enable multiplatform feature
   gem install --no-document bundler && \
   rm -rf /var/lib/apt/lists/*

--- a/td-agent/apt/ubuntu-focal/Dockerfile
+++ b/td-agent/apt/ubuntu-focal/Dockerfile
@@ -49,6 +49,8 @@ RUN \
     zlib1g-dev && \
   apt build-dep -y ruby && \
   apt clean && \
+  # raise IPv4 priority
+  sed -i'' -e 's,#precedence ::ffff:0:0/96  100,precedence ::ffff:0:0/96  100,' /etc/gai.conf && \
   # enable multiplatform feature
   gem install --no-document --install-dir /usr/share/rubygems-integration/all bundler && \
   rm -rf /var/lib/apt/lists/*

--- a/td-agent/apt/ubuntu-xenial/Dockerfile
+++ b/td-agent/apt/ubuntu-xenial/Dockerfile
@@ -51,6 +51,8 @@ RUN \
     zlib1g-dev && \
   apt build-dep -y ruby && \
   apt clean && \
+  # raise IPv4 priority
+  sed -i'' -e 's,#precedence ::ffff:0:0/96  100,precedence ::ffff:0:0/96  100,' /etc/gai.conf && \
   # enable multiplatform feature
   gem install --no-document bundler && \
   rm -rf /var/lib/apt/lists/*

--- a/td-agent/yum/amazonlinux-2/Dockerfile
+++ b/td-agent/yum/amazonlinux-2/Dockerfile
@@ -42,6 +42,8 @@ RUN \
     zlib-devel \
     rpmlint && \
   amazon-linux-extras install ruby2.6 && \
+  # raise IPv4 priority
+  echo "precedence ::ffff:0:0/96" > /etc/gai.conf && \
   # enable multiplatform feature
   gem install --no-document bundler && \
   yum clean ${quiet} all

--- a/td-agent/yum/centos-6/Dockerfile
+++ b/td-agent/yum/centos-6/Dockerfile
@@ -46,6 +46,8 @@ RUN \
     tar \
     zlib-devel \
     rpmlint && \
+    # raise IPv4 priority
+    echo "precedence ::ffff:0:0/96" > /etc/gai.conf && \
     # enable multiplatform feature
     source /opt/rh/rh-ruby24/enable && gem install --no-document --install-dir /opt/rh/rh-ruby24/root/usr/share/gems/ bundler && \
   yum clean ${quiet} all

--- a/td-agent/yum/centos-7/Dockerfile
+++ b/td-agent/yum/centos-7/Dockerfile
@@ -46,6 +46,8 @@ RUN \
     tar \
     zlib-devel \
     rpmlint && \
+    # raise IPv4 priority
+    echo "precedence ::ffff:0:0/96" > /etc/gai.conf && \
     # enable multiplatform feature
     source /opt/rh/rh-ruby26/enable && gem install --no-document --install-dir /opt/rh/rh-ruby26/root/usr/share/gems bundler && \
   yum clean ${quiet} all

--- a/td-agent/yum/centos-8/Dockerfile
+++ b/td-agent/yum/centos-8/Dockerfile
@@ -45,6 +45,8 @@ RUN \
     tar \
     zlib-devel \
     rpmlint && \
+    # raise IPv4 priority
+    echo "precedence ::ffff:0:0/96" > /etc/gai.conf && \
     # enable multiplatform feature
     gem install --no-document --install-dir /usr/share/gems bundler && \
   yum clean ${quiet} all

--- a/td-agent/yum/centos-stream-8/Dockerfile
+++ b/td-agent/yum/centos-stream-8/Dockerfile
@@ -48,6 +48,8 @@ RUN \
     tar \
     zlib-devel \
     rpmlint && \
+    # raise IPv4 priority
+    echo "precedence ::ffff:0:0/96" > /etc/gai.conf && \
     # enable multiplatform feature
     gem install --no-document --install-dir /usr/share/gems bundler && \
   yum clean ${quiet} all


### PR DESCRIPTION
If IPv6 is preferred in container, we can not
connect to rubygems.org. it causes timeout error.