### PR TITLE
RPM: Remove conflicted `provides` libraries

### DIFF
--- a/td-agent/yum/td-agent.spec.in
+++ b/td-agent/yum/td-agent.spec.in
@@ -17,6 +17,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
+%global __provides_exclude_from ^/opt/%{name}/.*\\.so.*
+%global __requires_exclude libjemalloc.*|libruby.*|/opt/%{name}/.*
+
 %define _centos_ver %{?centos_ver:%{centos_ver}}%{!?centos_ver:8}
 %define _amazon_ver %{?amzn:%{amzn}}%{!?amzn:0}
 %define use_scl_ruby (%{_centos_ver} <= 7 && %{_amazon_ver} == 0)
@@ -82,7 +85,6 @@ BuildRequires: systemd
 Requires: redhat-lsb-core
 %endif
 Requires(pre): /usr/bin/getent, /usr/sbin/adduser
-
 
 %description
 The stable distribution of Fluentd, called td-agent.


### PR DESCRIPTION
The following libraies that provided by td-agent 4 conflict with system's one:

  * libjemalloc.so.2()(64bit)
  * librdkafka.so.1()(64bit)
  * libruby.so.2.7()(64bit)

All shared libraries under /opt/td-agent/ should be ignored.
Otherwise td-agent may be installed unexpectedly when a package that requires these libraries is installed.
