### PR TITLE
yum: raise IPv4 priority correctly

### DIFF
--- a/td-agent/yum/amazonlinux-2/Dockerfile
+++ b/td-agent/yum/amazonlinux-2/Dockerfile
@@ -43,7 +43,7 @@ RUN \
     rpmlint && \
   amazon-linux-extras install ruby2.6 && \
   # raise IPv4 priority
-  echo "precedence ::ffff:0:0/96" > /etc/gai.conf && \
+  echo "precedence ::ffff:0:0/96 100" > /etc/gai.conf && \
   # enable multiplatform feature
   gem install --no-document bundler && \
   yum clean ${quiet} all

--- a/td-agent/yum/centos-6/Dockerfile
+++ b/td-agent/yum/centos-6/Dockerfile
@@ -47,7 +47,7 @@ RUN \
     zlib-devel \
     rpmlint && \
     # raise IPv4 priority
-    echo "precedence ::ffff:0:0/96" > /etc/gai.conf && \
+    echo "precedence ::ffff:0:0/96 100" > /etc/gai.conf && \
     # enable multiplatform feature
     source /opt/rh/rh-ruby24/enable && gem install --no-document --install-dir /opt/rh/rh-ruby24/root/usr/share/gems/ bundler && \
   yum clean ${quiet} all

--- a/td-agent/yum/centos-7/Dockerfile
+++ b/td-agent/yum/centos-7/Dockerfile
@@ -47,7 +47,7 @@ RUN \
     zlib-devel \
     rpmlint && \
     # raise IPv4 priority
-    echo "precedence ::ffff:0:0/96" > /etc/gai.conf && \
+    echo "precedence ::ffff:0:0/96 100" > /etc/gai.conf && \
     # enable multiplatform feature
     source /opt/rh/rh-ruby26/enable && gem install --no-document --install-dir /opt/rh/rh-ruby26/root/usr/share/gems bundler && \
   yum clean ${quiet} all

--- a/td-agent/yum/centos-8/Dockerfile
+++ b/td-agent/yum/centos-8/Dockerfile
@@ -46,7 +46,7 @@ RUN \
     zlib-devel \
     rpmlint && \
     # raise IPv4 priority
-    echo "precedence ::ffff:0:0/96" > /etc/gai.conf && \
+    echo "precedence ::ffff:0:0/96 100" > /etc/gai.conf && \
     # enable multiplatform feature
     gem install --no-document --install-dir /usr/share/gems bundler && \
   yum clean ${quiet} all

--- a/td-agent/yum/centos-stream-8/Dockerfile
+++ b/td-agent/yum/centos-stream-8/Dockerfile
@@ -49,7 +49,7 @@ RUN \
     zlib-devel \
     rpmlint && \
     # raise IPv4 priority
-    echo "precedence ::ffff:0:0/96" > /etc/gai.conf && \
+    echo "precedence ::ffff:0:0/96 100" > /etc/gai.conf && \
     # enable multiplatform feature
     gem install --no-document --install-dir /usr/share/gems bundler && \
   yum clean ${quiet} all


### PR DESCRIPTION
The value of priority is not set correctly.

This affects the access timeout to rubygems.org during build on IPv6 preferred
host.