### PR TITLE
fix ci for windows, use heroku uri to check instead

### DIFF
--- a/td-agent/msi/pkgsize-test.ps1
+++ b/td-agent/msi/pkgsize-test.ps1
@@ -1,12 +1,24 @@
 $ErrorActionPreference = 'Stop'
 
-&git fetch --unshallow
-$previous_version = (git describe --abbrev=0 --tags) -Replace "v",""
-$previous_msi_name = "td-agent-${previous_version}-x64.msi"
-
-"Previous version: {0}" -F $previous_version | Write-Host
 $base_uri = "http://packages.treasuredata.com.s3.amazonaws.com"
-$response = Invoke-WebRequest -Uri "${base_uri}/4/windows/${previous_msi_name}" -OutFile $previous_msi_name -PassThru
+&git fetch --unshallow
+try {
+    $previous_version = (git describe --abbrev=0 --tags) -Replace "v",""
+    "Previous version from git: {0}" -F $previous_version | Write-Host
+    $previous_msi_name = "td-agent-${previous_version}-x64.msi"
+    $response = Invoke-WebRequest -Uri "${base_uri}/4/windows/${previous_msi_name}" -OutFile $previous_msi_name -PassThru
+}
+catch {
+    $heroku_uri = 'http://td-agent-package-browser.herokuapp.com'
+    Write-Host "An exception was caught: $($_.Exception.Message). Try to find previous version in ${heroku_uri} instead"
+    $msi_links = (Invoke-WebRequest -Uri "${heroku_uri}/4/windows").Links.href | Where-Object {$_ -like "*.msi"}
+    $msi_versions = $($msi_links | Select-String '(\d+\.\d+\.\d+)' | ForEach-Object { $_.Matches[0].Groups[1].Value }) | Sort-Object {[version] $_}
+    $previous_version = $msi_versions | Select-Object -Last 1
+    "Previous version from {0}: {1}" -F ${heroku_uri}, $previous_version | Write-Host
+    $previous_msi_name = "td-agent-${previous_version}-x64.msi"
+    $response = Invoke-WebRequest -Uri "${base_uri}/4/windows/${previous_msi_name}" -OutFile $previous_msi_name -PassThru
+}
+
 $msi = (Get-Item "td-agent\\msi\\repositories\\td-agent-*.msi") | Sort-Object -Descending { $_.LastWriteTime } | Select-Object -First 1
 "Checking package size: {0}" -F $msi.FullName | Write-Host
 $package_size_threshold = $response.RawContentLength * 1.2


### PR DESCRIPTION
to fix  https://github.com/fluent-plugins-nursery/td-agent-builder/issues/278

@ashie , fyi