### PR TITLE
Work arround to avoid installing fat gem of nokogiri 1.11 on CentOS 6

### DIFF
--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -403,6 +403,10 @@ class BuildTask
         ENV["GEM_HOME"] = gem_staging_dir
         sh(bundle_command, "_#{BUNDLER_VERSION}_", "install")
         ENV["GEM_HOME"] = gem_home
+
+        # for fat gems which depend on nonexistent libraries
+        # mainly for nokogiri 1.11 or later on CentOS 6
+        rebuild_gems
       end
 
       desc "Install fluentd"
@@ -853,7 +857,7 @@ class BuildTask
     staging_dir
   end
 
-  def gem_install(gem_path, version = nil)
+  def gem_install(gem_path, version = nil, platform: nil)
     ensure_directory(staging_bindir)
     ensure_directory(gem_staging_dir)
 
@@ -870,6 +874,10 @@ class BuildTask
       gem_installation_command << "--version"
       gem_installation_command << version
     end
+    if platform
+      gem_installation_command << "--platform"
+      gem_installation_command << platform
+    end
     if macos? && gem_path.include?("rdkafka")
       ENV["CPPFLAGS"] = "-I#{File.join(STAGING_DIR, install_prefix, 'include')}"
       ENV["LDFLAGS"] = "-L#{File.join(STAGING_DIR, install_prefix, 'lib')}"
@@ -883,6 +891,43 @@ class BuildTask
     sh(*gem_installation_command)
 
     ENV["GEM_HOME"] = gem_home
+  end
+
+  def gem_uninstall(gem, version = nil)
+    ensure_directory(staging_bindir)
+    ensure_directory(gem_staging_dir)
+
+    gem_home = ENV["GEM_HOME"]
+    ENV["GEM_HOME"] = gem_staging_dir
+
+    gem_uninstallation_command = [
+      gem_command, "uninstall",
+      "--bindir", staging_bindir,
+      "--silent",
+      gem
+    ]
+    if version
+      gem_uninstallation_command << "--version"
+      gem_uninstallation_command << version
+    else
+      gem_uninstallation_command << "--all"
+    end
+    @logger.info("uninstall: <#{gem}>")
+    sh(*gem_uninstallation_command)
+
+    ENV["GEM_HOME"] = gem_home
+  end
+
+  def rebuild_gems
+    return unless ENV["REBUILD_GEMS"]
+
+    require 'bundler'
+    ENV["REBUILD_GEMS"].split((/\s+/)).each do |gem_name|
+      d = Bundler::Definition.build('Gemfile', 'Gemfile.lock', false)
+      version = d.locked_deps[gem_name].requirement.requirements[0][1].version
+      gem_uninstall(gem_name)
+      gem_install(gem_name, version, platform: "ruby")
+    end
   end
 
   def install_jemalloc_license

--- a/td-agent/yum/td-agent.spec.in
+++ b/td-agent/yum/td-agent.spec.in
@@ -108,10 +108,12 @@ The stable distribution of Fluentd, called td-agent.
 %endif
 %if %{use_systemd}
 rake build:rpm_config TD_AGENT_STAGING_PATH=%{buildroot} NO_VAR_RUN=1
+rake build:all TD_AGENT_STAGING_PATH=%{buildroot}
 %else
 rake build:rpm_old_config TD_AGENT_STAGING_PATH=%{buildroot} NO_VAR_RUN=0
+# Fat gem of nokogiri 1.11 requires glibc 2.17 which doesn't exist on CentOS 6
+rake build:all TD_AGENT_STAGING_PATH=%{buildroot} REBUILD_GEMS="nokogiri"
 %endif
-rake build:all TD_AGENT_STAGING_PATH=%{buildroot}
 mkdir -p %{buildroot}%{_mandir}/man1
 cp @PACKAGE@/debian/*.1 %{buildroot}%{_mandir}/man1/
 for man in `find %{buildroot} -type f -wholename '*/man/man[1-9]/*.[1-9]'`; do


### PR DESCRIPTION
Because it depends on glibc 2.17 which doesn't exist in CentOS 6.
