### PR TITLE
Remove needless dependencies on RHEL/CentOS 6, again

### DIFF
--- a/td-agent/yum/td-agent.spec.in
+++ b/td-agent/yum/td-agent.spec.in
@@ -32,6 +32,9 @@
 %undefine __brp_mangle_shebangs
 
 %if %{_centos_ver} < 7
+%filter_provides_in .*\.so
+%filter_from_provides /pkgconfig.*/d
+%filter_from_provides /perl.*/d
 %filter_requires_in libjemalloc.*
 %filter_requires_in libruby.*
 %filter_from_requires /\/opt\/td-agent\/bin\/ruby/d


### PR DESCRIPTION
5c905844edf9e4a2db556ef9ba16f4e3c4ea9c76 lacks filters for provides.
