### PR TITLE
package-task: Handle centos-stream-8-aarch64 yum target properly

### DIFF
--- a/lib/package-task.rb
+++ b/lib/package-task.rb
@@ -341,7 +341,12 @@ RELEASE=#{@rpm_release}
     cd(yum_dir) do
       yum_targets.each do |target|
         next unless Dir.exist?(target)
-        distribution, version, architecture = target.split("-", 3)
+        if target.include?("centos-stream")
+          distribution, suffix, version, architecture = target.split("-", 4)
+          distribution = "#{distribution}-#{suffix}"
+        else
+          distribution, version, architecture = target.split("-", 3)
+        end
         os = "#{distribution}-#{version}"
         run_docker(os, architecture)
       end


### PR DESCRIPTION
Otherwise, the current implementation will handle wrongly for
centos-stream-8-aarch64 target case:

```console
docker build --tag custom-fluentd-centos-stream-8-aarch64 --build-arg \
DEBUG=yes --build-arg FROM=arm64v8/centos:8 centos-stream
```

This can cause the following error:

```log
docker build --tag custom-fluentd-centos-stream-8-aarch64 --build-arg DEBUG=yes --build-arg FROM=arm64v8/centos:8 centos-stream
unable to prepare context: path "centos-stream" not found
rake aborted!
Command failed with status (1): [docker build --tag calyptia-fluentd-centos...]
/media/Data2/Gitrepo/custom-fluentd-builder/lib/package-task.rb:148:in `run_docker'
/media/Data2/Gitrepo/custom-fluentd-builder/lib/package-task.rb:346:in `block (2 levels) in yum_build'
/media/Data2/Gitrepo/custom-fluentd-builder/lib/package-task.rb:342:in `each'
/media/Data2/Gitrepo/custom-fluentd-builder/lib/package-task.rb:342:in `block in yum_build'
/media/Data2/Gitrepo/custom-fluentd-builder/lib/package-task.rb:341:in `yum_build'
/media/Data2/Gitrepo/custom-fluentd-builder/lib/package-task.rb:373:in `block (2 levels) in define_yum_task'
Tasks: TOP => yum:build
(See full trace by running task with --trace)
rake aborted!
Command failed with status (1): [/home/cosmo/.rbenv/versions/2.6.3/bin/ruby...]
/media/Data2/Gitrepo/custom-fluentd-builder/Rakefile:36:in `block (3 levels) in define_bulked_task'
/media/Data2/Gitrepo/custom-fluentd-builder/Rakefile:35:in `block (2 levels) in define_bulked_task'
/media/Data2/Gitrepo/custom-fluentd-builder/Rakefile:34:in `each'
/media/Data2/Gitrepo/custom-fluentd-builder/Rakefile:34:in `block in define_bulked_task'
Tasks: TOP => yum:build
(See full trace by running task with --trace)
```

---

I found it during custom fluentd packaging tasks.
CentOS Stream 8 AArch64 is one of the special case.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>