### PR TITLE
Fix wrong Ubuntu 21.04 codename

### DIFF
--- a/td-agent/apt/commonvar.sh
+++ b/td-agent/apt/commonvar.sh
@@ -9,7 +9,7 @@ case ${code_name} in
     mirror=http://archive.ubuntu.com/ubuntu/
     java_jdk=openjdk-8-jre
     ;;
-  bionic|focal|hirsure)
+  bionic|focal|hirsute)
     distribution=ubuntu
     channel=universe
     mirror=http://archive.ubuntu.com/ubuntu/


### PR DESCRIPTION
This causes unbound variable error on using ubuntu:firsute image.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>