### PR TITLE
td-agent-apt-source: Refer component variable

### DIFF
--- a/td-agent-apt-source/debian/rules
+++ b/td-agent-apt-source/debian/rules
@@ -26,7 +26,7 @@ override_dh_auto_build:
 	  echo "Types: deb"; \
 	  echo "URIs: http://packages.treasuredata.com/4/$${distribution}/$${code_name}/"; \
 	  echo "Suites: $${code_name}"; \
-	  echo "Components: contrib"; \
+	  echo "Components: $${component}"; \
 	  echo "Signed-By: /usr/share/keyrings/td-agent-archive-keyring.gpg"; \
 	) > td-agent.sources
 


### PR DESCRIPTION
This should be needed for Debian Buster td-agent-apt-source package.
Otherwise, apt complains the following component misspelt error:

xxx doesn't have the component 'contrib' (component misspelt in sources.list?)

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>

---

This bug can be found with a created repository by aptly on AWS S3.