### PR TITLE
Escape % in td-agent.service

### DIFF
--- a/td-agent/templates/etc/systemd/td-agent.service.erb
+++ b/td-agent/templates/etc/systemd/td-agent.service.erb
@@ -1,6 +1,6 @@
 [Unit]
 Description=<%= project_name %>: Fluentd based data collector for Treasure Data
-Documentation=https://docs.treasuredata.com/display/public/PD/About+Treasure+Data%27s+Server-Side+Agent
+Documentation=https://docs.treasuredata.com/display/public/PD/About+Treasure+Data%%27s+Server-Side+Agent
 After=network-online.target
 Wants=network-online.target
 


### PR DESCRIPTION
Fix the following error:

Apr 27 01:27:04 localhost.localdomain systemd[1]: /usr/lib/systemd/system/td-agent.service:3: Failed to resolve unit specifiers in ''https://docs.treasur>

Signed-off-by: Takuro Ashie <ashie@clear-code.com>