### PR TITLE
Update bindata to 2.4.10

### DIFF
--- a/td-agent/Gemfile.lock
+++ b/td-agent/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.3)
       aws-eventstream (~> 1, >= 1.0.2)
-    bindata (2.4.9)
+    bindata (2.4.10)
     concurrent-ruby (1.1.8)
     console (1.11.1)
       fiber-local


### PR DESCRIPTION
See https://github.com/advisories/GHSA-hj56-84jw-67h6

  CVE-2021-32823
  Vulnerable versions: < 2.4.10
  Patched version: 2.4.10

