### PR TITLE
Use YAML.safe_load explicitly

### DIFF
--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -1096,7 +1096,14 @@ class LinuxPackageTask < PackageTask
       unless status.success?
         fail "Failed to get gem specification: <#{gem_file}> (stdout: #{output}, stderr: #{error})"
       end
-      spec = YAML.load(output)
+      spec = YAML.safe_load(output,
+                            permitted_classes: [
+                              Time,
+                              Symbol,
+                              Gem::Specification,
+                              Gem::Version,
+                              Gem::Dependency,
+                              Gem::Requirement])
       relative_path = gem_file.sub(/#{Dir.pwd}\//, "")
       unless spec.licenses.empty?
         spdx_compatible_license = spec.licenses.first.sub(/Apache 2\.0/, "Apache-2.0")


### PR DESCRIPTION
If Psych backend v4.0.0 or later is used for YAML, it fails to load
because of incompatibility of YAML.load.

For example, it causes the following error.

```
cd td-agent
/home/kenhys/.rvm/rubies/ruby-2.7.3/bin/ruby -S rake apt:build
rake aborted!
Psych::DisallowedClass: Tried to load unspecified class: Gem::Specification
/home/kenhys/.rvm/gems/ruby-2.7.3@fluentd-test/gems/psych-4.0.1/lib/psych/class_loader.rb:99:in `find'
/home/kenhys/.rvm/gems/ruby-2.7.3@fluentd-test/gems/psych-4.0.1/lib/psych/class_loader.rb:28:in `load'
```

As it is known that what class will be actually loaded, it should use
YAML.safe_load and permit class explicitly.

This fix is compatible with Psych v3.x and v4.x.

Signed-off-by: Kentaro Hayashi <hayashi@clear-code.com>