### PR TITLE
msi: use 7z to extract tar.gz archive

### DIFF
--- a/td-agent/msi/build.bat
+++ b/td-agent/msi/build.bat
@@ -1,6 +1,6 @@
 SET SRC_DIR=%~dp0
 CALL "%SRC_DIR%env.bat"
 
-tar xvf "%SRC_DIR%..\%PACKAGE%-%VERSION%.tar.gz"
+7z x "%SRC_DIR%..\%PACKAGE%-%VERSION%.tar.gz" & 7z x "%PACKAGE%-%VERSION%.tar"
 cd "%PACKAGE%-%VERSION%"
 rake msi:selfbuild TD_AGENT_STAGING_PATH="C:/opt/td-agent" TD_AGENT_MSI_OUTPUT_PATH="%SRC_DIR%\repositories"


### PR DESCRIPTION
Recently, fresh build fails because of missing tar command.
7z.exe is installed as a toolchain, it is changed to use it.

It fixes the following error:

```cmd
  Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
  docker run --rm --tty --volume C:/work/td-agent-builder/td-agent-builder.msi:c:/td-agent-builder:rw td-agent-windows-x64 c:\td-agent-builder\td-agent\msi\build.bat

  C:\>SET SRC_DIR=c:\td-agent-builder\td-agent\msi\

  C:\>CALL "c:\td-agent-builder\td-agent\msi\env.bat"

  C:\>SET PACKAGE=td-agent

  C:\>SET VERSION=4.1.1

  C:\>SET ARCH=x64

  C:\>tar xvf "c:\td-agent-builder\td-agent\msi\..\td-agent-4.1.1.tar.gz"
  rake aborted!
  Command failed with status (): [docker run --rm --tty --volume C:/work/td-...]
  C:/work/td-agent-builder/td-agent-builder.msi/td-agent/Rakefile:1566:in `run_docker'
  C:/work/td-agent-builder/td-agent-builder.msi/td-agent/Rakefile:1484:in `block (2 levels) in define'
  C:/work/td-agent-builder/td-agent-builder.msi/td-agent/Rakefile:1474:in `block (2 levels) in define'
  Tasks: TOP => msi:dockerbuild
  (See full trace by running task with --trace)
  I, [2021-06-29T11:28:07.190678 #2624]  INFO -- : Generate debian/copyright
  rake aborted!
  Command failed with status (1): [C:/Ruby27-x64/bin/ruby.exe -S rake msi:bui...]
  C:/work/td-agent-builder/td-agent-builder.msi/Rakefile:36:in `block (3 levels) in define_bulked_task'
  C:/work/td-agent-builder/td-agent-builder.msi/Rakefile:35:in `block (2 levels) in define_bulked_task'
  C:/work/td-agent-builder/td-agent-builder.msi/Rakefile:34:in `each'
  C:/work/td-agent-builder/td-agent-builder.msi/Rakefile:34:in `block in define_bulked_task'
  Tasks: TOP => msi:build
  (See full trace by running task with --trace)

```