### PR TITLE
Remove jeprof

### DIFF
--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -1045,6 +1045,7 @@ class BuildTask
   end
 
   def remove_needless_files
+    remove_files("#{td_agent_staging_dir}/bin/jeprof", true)
     remove_files("#{td_agent_staging_dir}/share/doc", true) # Contains only jemalloc.html
     remove_files("#{td_agent_staging_dir}/share/ri", true)
     cd("#{gem_staging_dir}/cache") do


### PR DESCRIPTION
It won't be used in production environments.
And it introduces unnecessary dependencies.

Fix #306

Signed-off-by: Takuro Ashie <ashie@clear-code.com>